### PR TITLE
add exposed-headers:Location for Keycloak

### DIFF
--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -72,6 +72,7 @@ app:
 keycloak:
   enabled: ${KEYCLOAK_ENABLED:true}
   cors: true
+  cors-exposed-headers: Location
   bearer-only: true
   auth-server-url: ${KEYCLOAK_BASE_URL:http://localhost:8080}/auth
   realm: ${KEYCLOAK_REALM:codex-develop}
@@ -92,6 +93,6 @@ logging:
 
 cors:
   allowedOrigins:
-  - "*"
+    - "*"
 
 


### PR DESCRIPTION
Allow Keycloak to bypass the Header.Location param. Was necessary after changing the query reply from 200-OK to 201-CREATED.