### PR TITLE
Add Missing Name Attribute to Library using DSF

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,7 @@
 FROM openjdk:17
 
+RUN microdnf upgrade
+
 WORKDIR /opt/codex-feasibility-backend
 COPY ./target/*.jar ./feasibility-gui-backend.jar
 COPY ontology ontology

--- a/pom.xml
+++ b/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>org.springframework.boot</groupId>
     <artifactId>spring-boot-starter-parent</artifactId>
-    <version>2.6.6</version>
+    <version>2.6.7</version>
     <relativePath /> <!-- lookup parent from repository -->
   </parent>
   <groupId>de.medizininformatik-initiative</groupId>
@@ -23,7 +23,7 @@
 
   <properties>
     <java.version>17</java.version>
-    <mockwebserver.version>4.9.1</mockwebserver.version>
+    <mockwebserver.version>4.9.3</mockwebserver.version>
     <okhttp3.version>4.9.1</okhttp3.version>
     <log4j2.version>2.16.0</log4j2.version>
   </properties>
@@ -33,14 +33,14 @@
       <dependency>
         <groupId>org.keycloak.bom</groupId>
         <artifactId>keycloak-adapter-bom</artifactId>
-        <version>16.1.1</version>
+        <version>18.0.0</version>
         <type>pom</type>
         <scope>import</scope>
       </dependency>
       <dependency>
         <groupId>org.bouncycastle</groupId>
         <artifactId>bcpkix-jdk15on</artifactId>
-        <version>1.69</version>
+        <version>1.70</version>
       </dependency>
     </dependencies>
   </dependencyManagement>
@@ -70,7 +70,7 @@
     <dependency>
       <groupId>org.keycloak</groupId>
       <artifactId>keycloak-spring-boot-starter</artifactId>
-      <version>16.1.1</version>
+      <version>18.0.0</version>
     </dependency>
 
     <dependency>
@@ -109,20 +109,20 @@
     <dependency>
       <groupId>org.projectlombok</groupId>
       <artifactId>lombok</artifactId>
-      <version>1.18.22</version>
+      <version>1.18.24</version>
       <scope>provided</scope>
     </dependency>
 
     <dependency>
       <groupId>org.springdoc</groupId>
       <artifactId>springdoc-openapi-ui</artifactId>
-      <version>1.5.3</version>
+      <version>1.6.8</version>
     </dependency>
 
     <dependency>
       <groupId>com.github.erosb</groupId>
       <artifactId>everit-json-schema</artifactId>
-      <version>1.14.0</version>
+      <version>1.14.1</version>
     </dependency>
 
     <dependency>
@@ -178,21 +178,21 @@
     <dependency>
       <groupId>org.testcontainers</groupId>
       <artifactId>testcontainers</artifactId>
-      <version>1.16.2</version>
+      <version>1.17.1</version>
       <scope>test</scope>
     </dependency>
 
     <dependency>
       <groupId>org.testcontainers</groupId>
       <artifactId>junit-jupiter</artifactId>
-      <version>1.16.2</version>
+      <version>1.17.1</version>
       <scope>test</scope>
     </dependency>
 
     <dependency>
       <groupId>org.testcontainers</groupId>
       <artifactId>postgresql</artifactId>
-      <version>1.16.2</version>
+      <version>1.17.1</version>
       <scope>test</scope>
     </dependency>
 

--- a/src/main/java/de/numcodex/feasibility_gui_backend/query/broker/dsf/DSFQueryManager.java
+++ b/src/main/java/de/numcodex/feasibility_gui_backend/query/broker/dsf/DSFQueryManager.java
@@ -41,6 +41,8 @@ class DSFQueryManager implements QueryManager {
     private static final String REQUESTER_TYPE = "Organization";
     private static final String RECIPIENT_TYPE = "Organization";
 
+    private static final String LIBRARY_NAME = "Retrieve";
+
     private static final String CODE_SYSTEM_FEASIBILITY = "https://www.netzwerk-universitaetsmedizin.de/fhir/CodeSystem/feasibility";
     private static final String CODE_SYSTEM_FEASIBILITY_VALUE_MEASURE_REFERENCE = "measure-reference";
     private static final String CODE_SYSTEM_ORGANIZATION = "http://highmed.org/sid/organization-identifier";
@@ -210,6 +212,7 @@ class DSFQueryManager implements QueryManager {
     private Bundle addLibrary(Bundle queryBundle, Map<String, String> queryContents, UUID libraryId) {
         Bundle bundle = queryBundle.copy();
         Library library = new Library()
+                .setName(LIBRARY_NAME)
                 .setStatus(ACTIVE)
                 .setType(new CodeableConcept()
                         .addCoding(new Coding()

--- a/src/test/java/de/numcodex/feasibility_gui_backend/query/broker/dsf/DSFQueryManagerTest.java
+++ b/src/test/java/de/numcodex/feasibility_gui_backend/query/broker/dsf/DSFQueryManagerTest.java
@@ -7,6 +7,7 @@ import org.hl7.fhir.r4.model.Bundle;
 import org.hl7.fhir.r4.model.Bundle.BundleEntryComponent;
 import org.hl7.fhir.r4.model.Library;
 import org.hl7.fhir.r4.model.Task;
+import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -131,11 +132,15 @@ public class DSFQueryManagerTest {
         List<BundleEntryComponent> bundleEntries = bundleCaptor.getValue().getEntry();
         var task = (Task) bundleEntries.stream().filter(e -> e.getResource().fhirType().equals("Task")).findFirst()
                 .orElseThrow().getResource();
-
         var businessKey = task.getInput().stream().filter(i -> i.getType().getCodingFirstRep().getCode().equals("business-key"))
                 .findFirst().orElseThrow().getValue().toString();
 
+        var library = (Library) bundleEntries.stream().filter(e -> e.getResource().fhirType().equals("Library"))
+                .findFirst().orElseThrow().getResource();
+
+
         assertEquals(businessKey, queryId);
+        assertNotNull(library.getName());
     }
 
     @Test


### PR DESCRIPTION
Adds a name attribute to any library resource created
using the DSF client. This fixes issues when using a
HAPI FHIR server that is about to evaluate a measure
referencing such a library.

Fixes #6