### PR TITLE
Make Security Scan Job Skippable

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -66,6 +66,7 @@ jobs:
 
   security-scan:
     runs-on: ubuntu-latest
+    if: ${{ !contains(github.event.head_commit.message, '[skip security-scan]') }}
     steps:
     - uses: actions/checkout@v2
 
@@ -108,7 +109,12 @@ jobs:
         severity: 'CRITICAL,HIGH'
 
   release:
-    if: ${{ startsWith(github.ref, 'refs/tags/v') }}
+    if: |
+      always() &&
+      needs.unit-tests.result == 'success' &&
+      (needs.security-scan.result == 'success' || needs.security-scan.result == 'skipped') &&
+      needs.integration-tests.result == 'success' &&
+      startsWith(github.ref, 'refs/tags/v')
     needs: [ unit-tests, security-scan, integration-tests ]
     runs-on: ubuntu-latest
     steps:


### PR DESCRIPTION
Add ability to skip the security scan workflow job by adding '[skip security-scan]' flag to head commit message.