### PR TITLE
Switch to Eclipse Temurin Images

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -18,9 +18,9 @@ jobs:
       - uses: actions/checkout@v2
 
       - name: Set up JDK 17
-        uses: actions/setup-java@v2
+        uses: actions/setup-java@v3
         with:
-          distribution: 'zulu'
+          distribution: 'temurin'
           java-version: 17
 
       - name: Cache Local Maven Repo
@@ -44,9 +44,9 @@ jobs:
       - uses: actions/checkout@v2
 
       - name: Set up JDK 17
-        uses: actions/setup-java@v2
+        uses: actions/setup-java@v3
         with:
-          distribution: 'zulu'
+          distribution: 'temurin'
           java-version: 17
 
       - name: Cache Local Maven Repo
@@ -115,9 +115,9 @@ jobs:
     - uses: actions/checkout@v2
 
     - name: Set up JDK 17
-      uses: actions/setup-java@v2
+      uses: actions/setup-java@v3
       with:
-        distribution: 'zulu'
+        distribution: 'temurin'
         java-version: 17
 
     - name: Cache Local Maven Repo

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,6 @@
-FROM openjdk:17
+FROM eclipse-temurin:17-jre
 
-RUN microdnf upgrade
+RUN apt update -yqq && apt upgrade -yqq
 
 WORKDIR /opt/codex-feasibility-backend
 COPY ./target/*.jar ./feasibility-gui-backend.jar

--- a/pom.xml
+++ b/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>org.springframework.boot</groupId>
     <artifactId>spring-boot-starter-parent</artifactId>
-    <version>2.6.7</version>
+    <version>2.7.1</version>
     <relativePath /> <!-- lookup parent from repository -->
   </parent>
   <groupId>de.medizininformatik-initiative</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>org.springframework.boot</groupId>
     <artifactId>spring-boot-starter-parent</artifactId>
-    <version>2.7.1</version>
+    <version>2.7.2</version>
     <relativePath /> <!-- lookup parent from repository -->
   </parent>
   <groupId>de.medizininformatik-initiative</groupId>


### PR DESCRIPTION
Resolves #12 

Makes use of new Eclipse Temurin images in both artifacts and CI jobs.
Also updates the Spring version to fix a security vulnerability.