### PR TITLE
Asynchronously Dispatch Queries via Brokers

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -208,6 +208,13 @@
       <scope>test</scope>
     </dependency>
 
+    <dependency>
+      <groupId>io.projectreactor</groupId>
+      <artifactId>reactor-test</artifactId>
+      <version>3.4.22</version>
+      <scope>test</scope>
+    </dependency>
+
   </dependencies>
 
   <repositories>

--- a/src/main/java/de/numcodex/feasibility_gui_backend/query/dispatch/QueryDispatchSpringConfig.java
+++ b/src/main/java/de/numcodex/feasibility_gui_backend/query/dispatch/QueryDispatchSpringConfig.java
@@ -7,8 +7,12 @@ import de.numcodex.feasibility_gui_backend.query.persistence.QueryDispatchReposi
 import de.numcodex.feasibility_gui_backend.query.persistence.QueryRepository;
 import de.numcodex.feasibility_gui_backend.query.translation.QueryTranslationComponent;
 import org.springframework.beans.factory.annotation.Qualifier;
+import org.springframework.beans.factory.config.ConfigurableBeanFactory;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
+import org.springframework.context.annotation.Scope;
+import org.springframework.core.task.TaskExecutor;
+import org.springframework.scheduling.concurrent.ThreadPoolTaskExecutor;
 
 import java.security.MessageDigest;
 import java.security.NoSuchAlgorithmException;
@@ -17,17 +21,19 @@ import java.util.List;
 @Configuration
 public class QueryDispatchSpringConfig {
 
+    // Keep the dispatcher a singleton instance since it uses a task executor.
+    // Without this you may use more threads than intended.
     @Bean
     public QueryDispatcher createQueryDispatcher(
-            @Qualifier("brokerClients") List<BrokerClient> brokerClients,
+            @Qualifier("brokerClients") List<BrokerClient> queryBrokerClients,
             QueryTranslationComponent queryTranslationComponent,
             QueryHashCalculator queryHashCalculator,
             @Qualifier("translation") ObjectMapper jsonUtil,
             QueryRepository queryRepository,
             QueryContentRepository queryContentRepository,
             QueryDispatchRepository queryDispatchRepository) {
-        return new QueryDispatcher(brokerClients, queryTranslationComponent, queryHashCalculator, jsonUtil,
-                queryRepository, queryContentRepository, queryDispatchRepository);
+        return new QueryDispatcher(queryBrokerClients, queryTranslationComponent, queryHashCalculator, jsonUtil, queryRepository,
+                queryContentRepository, queryDispatchRepository);
     }
 
     @Bean

--- a/src/main/java/de/numcodex/feasibility_gui_backend/query/dispatch/QueryDispatcher.java
+++ b/src/main/java/de/numcodex/feasibility_gui_backend/query/dispatch/QueryDispatcher.java
@@ -11,9 +11,12 @@ import de.numcodex.feasibility_gui_backend.query.persistence.*;
 import de.numcodex.feasibility_gui_backend.query.persistence.QueryDispatch.QueryDispatchId;
 import de.numcodex.feasibility_gui_backend.query.translation.QueryTranslationComponent;
 import de.numcodex.feasibility_gui_backend.query.translation.QueryTranslationException;
+import lombok.Getter;
 import lombok.NonNull;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import reactor.core.publisher.Flux;
+import reactor.core.publisher.Mono;
 
 import javax.transaction.Transactional;
 import java.io.IOException;
@@ -22,6 +25,7 @@ import java.time.Instant;
 import java.util.List;
 import java.util.Map;
 import java.util.Map.Entry;
+import java.util.function.Predicate;
 
 /**
  * Centralized component to enqueue and dispatch (publish) a {@link StructuredQuery}.
@@ -56,7 +60,7 @@ public class QueryDispatcher {
      * Enqueues a {@link StructuredQuery}, allowing it to be published afterwards. Enqueued queries are stored within
      * the database as a side effect.
      *
-     * @param query The query that shall be enqueued.
+     * @param query  The query that shall be enqueued.
      * @param userId keycloak auth id of the author of the query
      * @return Identifier of the enqueued query. This acts as a reference when trying to publish it.
      * @throws QueryDispatchException If an error occurs while enqueueing the query.
@@ -78,34 +82,70 @@ public class QueryDispatcher {
     }
 
     /**
-     * Dispatches (publishes) an already enqueued query in a broadcast fashion using configured {@link BrokerClient}s.
+     * Dispatches (publishes) an already enqueued query in a broadcast fashion using all configured {@link BrokerClient}s.
+     * The dispatch is designed to happen asynchronously (but not in parallel).
      *
      * @param queryId Identifies the backend query that shall be dispatched.
-     * @throws QueryDispatchException If an error occurs while dispatching the query.
+     * @return A {@link Mono} in complete state if at least a single broker managed to publish the query. If all brokers
+     *         failed to publish the query then a {@link Mono} in an error state is returned.
      */
     // TODO: Pass in audit information! (actor)
-    public void dispatchEnqueuedQuery(Long queryId) throws QueryDispatchException {
-        var enqueuedQuery = getEnqueuedQuery(queryId);
-        var deserializedQueryBody = getStructuredQueryFromEnqueuedQuery(enqueuedQuery);
-        var translatedQueryBodyFormats = translateQueryIntoTargetFormats(deserializedQueryBody);
-
-        // TODO: error handling + asynchronous dispatch!
+    public Mono<Void> dispatchEnqueuedQuery(Long queryId) {
         try {
-            for (BrokerClient broker : queryBrokerClients) {
-                var brokerQueryId = broker.createQuery(queryId);
+            var enqueuedQuery = getEnqueuedQuery(queryId);
+            var deserializedQueryBody = getStructuredQueryFromEnqueuedQuery(enqueuedQuery);
+            var translatedQueryBodyFormats = translateQueryIntoTargetFormats(deserializedQueryBody);
 
-                for (Entry<QueryMediaType, String> queryBodyFormats : translatedQueryBodyFormats.entrySet()) {
+            var dispatchable = new Dispatchable(enqueuedQuery, translatedQueryBodyFormats);
+
+            return Flux.fromIterable(queryBrokerClients)
+                    // do not try to make this parallel - it breaks transaction propagation!
+                    .flatMap(client -> dispatchAsynchronously(dispatchable, client))
+                    .all(Predicate.isEqual(false))
+                    .flatMap(allDispatchesFailed -> {
+                        if (allDispatchesFailed) {
+                            return Mono.error(new QueryDispatchException(("cannot dispatch query with id '%s'. " +
+                                    "Dispatch failed for all brokers").formatted(queryId)));
+                        } else {
+                            return Mono.empty();
+                        }
+                    })
+                    .then();
+        } catch (QueryDispatchException e) {
+            log.error("dispatch of query with id '%s' failed".formatted(queryId), e);
+            return Mono.error(new QueryDispatchException("dispatch of query with id '%s' failed".formatted(queryId), e));
+        }
+    }
+
+    /**
+     * Dispatches a single dispatchable entity (query) using the specified broker.
+     * Dispatching happens in an asynchronous fashion.
+     *
+     * @param dispatchable This is going to be dispatched.
+     * @param broker       This actually dispatches the dispatchable entity.
+     * @return A {@link Mono} holding the completion status of the dispatch operation that is either true
+     * (dispatch was successful) or false (dispatch failed).
+     */
+    private Mono<Boolean> dispatchAsynchronously(Dispatchable dispatchable, BrokerClient broker) {
+        return Mono.fromCallable(() -> {
+            try {
+                var brokerQueryId = broker.createQuery(dispatchable.query.getId());
+
+                for (Entry<QueryMediaType, String> queryBodyFormats : dispatchable.serializedQueryByFormat.entrySet()) {
                     broker.addQueryDefinition(brokerQueryId, queryBodyFormats.getKey().getRepresentation(),
                             queryBodyFormats.getValue());
                 }
                 broker.publishQuery(brokerQueryId);
-                persistDispatchedQuery(enqueuedQuery, brokerQueryId, broker.getBrokerType());
-                log.info("dispatched query '%s' as '%s' with broker type '%s'".formatted(queryId, brokerQueryId,
-                        broker.getBrokerType()));
+                persistDispatchedQuery(dispatchable.query, brokerQueryId, broker.getBrokerType());
+                log.info("dispatched query '%s' as '%s' with broker type '%s'".formatted(dispatchable.query.getId(),
+                        brokerQueryId, broker.getBrokerType()));
+                return true;
+            } catch (UnsupportedMediaTypeException | QueryNotFoundException | IOException e) {
+                log.error("failed to dispatch query '%s' with broker type '%s'"
+                        .formatted(dispatchable.query.getId(), broker.getBrokerType()));
+                return false;
             }
-        } catch (UnsupportedMediaTypeException | QueryNotFoundException | IOException e) {
-            throw new QueryDispatchException("cannot publish query with id '%s'".formatted(queryId), e);
-        }
+        });
     }
 
     private String serializedStructuredQuery(StructuredQuery query) throws QueryDispatchException {
@@ -158,5 +198,16 @@ public class QueryDispatcher {
         } catch (QueryTranslationException e) {
             throw new QueryDispatchException("cannot translate enqueued query body into configured formats", e);
         }
+    }
+
+    @Getter
+    @RequiredArgsConstructor
+    private static class Dispatchable {
+
+        @NonNull
+        private Query query;
+
+        @NonNull
+        private Map<QueryMediaType, String> serializedQueryByFormat;
     }
 }

--- a/src/main/java/de/numcodex/feasibility_gui_backend/query/v1/QueryHandlerRestController.java
+++ b/src/main/java/de/numcodex/feasibility_gui_backend/query/v1/QueryHandlerRestController.java
@@ -2,27 +2,22 @@ package de.numcodex.feasibility_gui_backend.query.v1;
 
 import de.numcodex.feasibility_gui_backend.query.QueryHandlerService;
 import de.numcodex.feasibility_gui_backend.query.api.StructuredQuery;
-import de.numcodex.feasibility_gui_backend.query.dispatch.QueryDispatchException;
-import java.security.Principal;
-import javax.servlet.http.HttpServletRequest;
-import javax.validation.Valid;
-import javax.ws.rs.core.Context;
 import lombok.extern.slf4j.Slf4j;
 import org.keycloak.KeycloakPrincipal;
 import org.keycloak.adapters.springsecurity.token.KeycloakAuthenticationToken;
 import org.springframework.beans.factory.annotation.Value;
-import org.springframework.http.HttpHeaders;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
-import org.springframework.web.bind.annotation.CrossOrigin;
-import org.springframework.web.bind.annotation.GetMapping;
-import org.springframework.web.bind.annotation.PathVariable;
-import org.springframework.web.bind.annotation.PostMapping;
-import org.springframework.web.bind.annotation.RequestBody;
-import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.bind.annotation.*;
 import org.springframework.web.servlet.support.ServletUriComponentsBuilder;
 import org.springframework.web.util.UriComponentsBuilder;
+import reactor.core.publisher.Mono;
+
+import javax.servlet.http.HttpServletRequest;
+import javax.validation.Valid;
+import javax.ws.rs.core.Context;
+import java.net.URI;
+import java.security.Principal;
 
 /*
 Rest Interface for the UI to send queries from the ui to the ui backend.
@@ -42,30 +37,34 @@ public class QueryHandlerRestController {
     this.apiBaseUrl = apiBaseUrl;
   }
 
-  @PostMapping("run-query")
+  @PostMapping(value = "run-query")
   @Deprecated
-  public ResponseEntity<Object> runQuery(@Valid @RequestBody StructuredQuery query,
-      @Context HttpServletRequest httpServletRequest, Principal principal) {
+  public Mono<ResponseEntity<Object>> runQuery(@Valid @RequestBody StructuredQuery query,
+                                               @Context HttpServletRequest request,
+                                               Principal principal) {
+    // Note: this is using a ResponseEntity instead of a ServerResponse since this is a
+    //       @Controller annotated class. This can be adjusted as soon as we switch to the new
+    //       functional web framework (if ever).
+    return queryHandlerService.runQuery(query, principal.getName())
+            .map(queryId -> buildResultLocationUri(request, queryId))
+            .map(resultLocation -> ResponseEntity.created(resultLocation).build())
+            .onErrorResume(e -> {
+                log.error("running a query for '%s' failed".formatted(principal.getName()), e);
+                return Mono.just(ResponseEntity.internalServerError()
+                                .body(e.getMessage()));
+            });
+  }
 
-    Long queryId;
-    try {
-      queryId = queryHandlerService.runQuery(query, principal.getName());
-    } catch (QueryDispatchException e) {
-      log.error("Error while running query", e);
-      return new ResponseEntity<>(HttpStatus.INTERNAL_SERVER_ERROR);
-    }
-
+  private URI buildResultLocationUri(HttpServletRequest httpServletRequest,
+                                     Long queryId) {
     UriComponentsBuilder uriBuilder = (apiBaseUrl != null && !apiBaseUrl.isEmpty())
-        ? ServletUriComponentsBuilder.fromUriString(apiBaseUrl)
-        : ServletUriComponentsBuilder.fromRequestUri(httpServletRequest);
+            ? ServletUriComponentsBuilder.fromUriString(apiBaseUrl)
+            : ServletUriComponentsBuilder.fromRequestUri(httpServletRequest);
 
-    var uriString = uriBuilder.replacePath("")
-        .pathSegment("api", "v1", "query-handler", "result", String.valueOf(queryId))
-        .build()
-        .toUriString();
-    HttpHeaders httpHeaders = new HttpHeaders();
-    httpHeaders.add(HttpHeaders.LOCATION, uriString);
-    return new ResponseEntity<>(httpHeaders, HttpStatus.CREATED);
+    return uriBuilder.replacePath("")
+            .pathSegment("api", "v1", "query-handler", "result", String.valueOf(queryId))
+            .build()
+            .toUri();
   }
 
   @GetMapping(path = "/result/{id}")

--- a/src/main/java/de/numcodex/feasibility_gui_backend/query/v2/QueryHandlerRestController.java
+++ b/src/main/java/de/numcodex/feasibility_gui_backend/query/v2/QueryHandlerRestController.java
@@ -7,33 +7,27 @@ import de.numcodex.feasibility_gui_backend.query.api.QueryListEntry;
 import de.numcodex.feasibility_gui_backend.query.api.QueryResult;
 import de.numcodex.feasibility_gui_backend.query.api.SavedQuery;
 import de.numcodex.feasibility_gui_backend.query.api.StructuredQuery;
-import de.numcodex.feasibility_gui_backend.query.dispatch.QueryDispatchException;
 import de.numcodex.feasibility_gui_backend.terminology.validation.TermCodeValidation;
-import java.security.Principal;
-import java.util.List;
-import java.util.Set;
-import javax.servlet.http.HttpServletRequest;
-import javax.validation.Valid;
-import javax.ws.rs.core.Context;
 import lombok.extern.slf4j.Slf4j;
 import org.keycloak.KeycloakPrincipal;
 import org.keycloak.adapters.RefreshableKeycloakSecurityContext;
 import org.keycloak.adapters.springsecurity.token.KeycloakAuthenticationToken;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.dao.DataIntegrityViolationException;
-import org.springframework.http.HttpHeaders;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
-import org.springframework.web.bind.annotation.CrossOrigin;
-import org.springframework.web.bind.annotation.GetMapping;
-import org.springframework.web.bind.annotation.PathVariable;
-import org.springframework.web.bind.annotation.PostMapping;
-import org.springframework.web.bind.annotation.RequestBody;
-import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RequestParam;
-import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.bind.annotation.*;
 import org.springframework.web.servlet.support.ServletUriComponentsBuilder;
 import org.springframework.web.util.UriComponentsBuilder;
+import reactor.core.publisher.Mono;
+
+import javax.servlet.http.HttpServletRequest;
+import javax.validation.Valid;
+import javax.ws.rs.core.Context;
+import java.net.URI;
+import java.security.Principal;
+import java.util.List;
+import java.util.Set;
 
 /*
 Rest Interface for the UI to send queries from the ui to the ui backend.
@@ -58,29 +52,33 @@ public class QueryHandlerRestController {
     this.apiBaseUrl = apiBaseUrl;
   }
 
-  @PostMapping("")
-  public ResponseEntity<Object> runQuery(@Valid @RequestBody StructuredQuery query,
-      @Context HttpServletRequest httpServletRequest, Principal principal) {
+  @PostMapping
+  public Mono<ResponseEntity<Object>> runQuery(@Valid @RequestBody StructuredQuery query,
+                                               @Context HttpServletRequest request,
+                                               Principal principal) {
+    // Note: this is using a ResponseEntity instead of a ServerResponse since this is a
+    //       @Controller annotated class. This can be adjusted as soon as we switch to the new
+    //       functional web framework (if ever).
+    return queryHandlerService.runQuery(query, principal.getName())
+            .map(queryId -> buildResultLocationUri(request, queryId))
+            .map(resultLocation -> ResponseEntity.created(resultLocation).build())
+            .onErrorResume(e -> {
+              log.error("running a query for '%s' failed".formatted(principal.getName()), e);
+              return Mono.just(ResponseEntity.internalServerError()
+                      .body(e.getMessage()));
+            });
+  }
 
-    Long queryId;
-    try {
-      queryId = queryHandlerService.runQuery(query, principal.getName());
-    } catch (QueryDispatchException e) {
-      log.error("Error while running query", e);
-      return new ResponseEntity<>(HttpStatus.INTERNAL_SERVER_ERROR);
-    }
+  private URI buildResultLocationUri(HttpServletRequest httpServletRequest,
+                                     Long queryId) {
+      UriComponentsBuilder uriBuilder = (apiBaseUrl != null && !apiBaseUrl.isEmpty())
+              ? ServletUriComponentsBuilder.fromUriString(apiBaseUrl)
+              : ServletUriComponentsBuilder.fromRequestUri(httpServletRequest);
 
-    UriComponentsBuilder uriBuilder = (apiBaseUrl != null && !apiBaseUrl.isEmpty())
-        ? ServletUriComponentsBuilder.fromUriString(apiBaseUrl)
-        : ServletUriComponentsBuilder.fromRequestUri(httpServletRequest);
-
-    var uriString = uriBuilder.replacePath("")
-        .pathSegment("api", "v2", "query", String.valueOf(queryId))
-        .build()
-        .toUriString();
-    HttpHeaders httpHeaders = new HttpHeaders();
-    httpHeaders.add(HttpHeaders.LOCATION, uriString);
-    return new ResponseEntity<>(httpHeaders, HttpStatus.CREATED);
+      return uriBuilder.replacePath("")
+              .pathSegment("api", "v2", "query", String.valueOf(queryId))
+              .build()
+              .toUri();
   }
 
   @GetMapping("")

--- a/src/test/java/de/numcodex/feasibility_gui_backend/query/QueryHandlerServiceIT.java
+++ b/src/test/java/de/numcodex/feasibility_gui_backend/query/QueryHandlerServiceIT.java
@@ -76,7 +76,7 @@ public class QueryHandlerServiceIT {
     public void testRunQuery() {
         var testStructuredQuery = new StructuredQuery();
 
-        assertDoesNotThrow(() -> queryHandlerService.runQuery(testStructuredQuery, "test"));
+        queryHandlerService.runQuery(testStructuredQuery, "test").block();
         assertEquals(1, queryRepository.count());
         assertEquals(1, queryDispatchRepository.count());
     }

--- a/src/test/java/de/numcodex/feasibility_gui_backend/query/dispatch/QueryDispatcherTest.java
+++ b/src/test/java/de/numcodex/feasibility_gui_backend/query/dispatch/QueryDispatcherTest.java
@@ -1,0 +1,216 @@
+package de.numcodex.feasibility_gui_backend.query.dispatch;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import de.numcodex.feasibility_gui_backend.query.QueryMediaType;
+import de.numcodex.feasibility_gui_backend.query.api.StructuredQuery;
+import de.numcodex.feasibility_gui_backend.query.broker.BrokerClient;
+import de.numcodex.feasibility_gui_backend.query.broker.QueryNotFoundException;
+import de.numcodex.feasibility_gui_backend.query.persistence.*;
+import de.numcodex.feasibility_gui_backend.query.translation.QueryTranslationComponent;
+import de.numcodex.feasibility_gui_backend.query.translation.QueryTranslationException;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.Mockito;
+import org.mockito.Spy;
+import org.mockito.junit.jupiter.MockitoExtension;
+import reactor.test.StepVerifier;
+
+import java.io.IOException;
+import java.net.URI;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+
+import static org.mockito.Mockito.*;
+
+@Tag("query")
+@Tag("dispatch")
+@ExtendWith(MockitoExtension.class)
+public class QueryDispatcherTest {
+
+    @Mock
+    private QueryTranslationComponent queryTranslationComponent;
+
+    @Mock
+    private QueryHashCalculator queryHashCalculator;
+
+    @Spy
+    private ObjectMapper jsonUtil = new ObjectMapper();
+
+    @Mock
+    private QueryRepository queryRepository;
+
+    @Mock
+    private QueryContentRepository queryContentRepository;
+
+    @Mock
+    private QueryDispatchRepository queryDispatchRepository;
+
+    private QueryDispatcher createQueryDispatcher(List<BrokerClient> brokerClients) {
+        return new QueryDispatcher(brokerClients, queryTranslationComponent, queryHashCalculator,
+                jsonUtil, queryRepository, queryContentRepository, queryDispatchRepository);
+    }
+
+
+    @BeforeEach
+    public void resetMocks() {
+        Mockito.reset(queryTranslationComponent, queryHashCalculator, jsonUtil, queryRepository, queryContentRepository,
+                queryDispatchRepository);
+    }
+
+    @Test
+    public void testDispatchEnqueuedQuery_FailsWhenUnableToGetEnqueuedQuery() {
+        var testQueryId = 99999L;
+        doReturn(Optional.empty()).when(queryRepository).findById(testQueryId);
+
+        var queryDispatcher = createQueryDispatcher(List.of());
+        StepVerifier.create(queryDispatcher.dispatchEnqueuedQuery(testQueryId))
+                .expectError(QueryDispatchException.class)
+                .verify();
+    }
+
+    @Test
+    public void testDispatchEnqueuedQuery_FailsWhenStructuredQueryNotFetchable() throws JsonProcessingException {
+        var testQueryId = 99999L;
+        var testQuery = new Query();
+        testQuery.setId(testQueryId);
+        var testQueryContent = new QueryContent(jsonUtil.writeValueAsString(new StructuredQuery()));
+        testQuery.setQueryContent(testQueryContent);
+
+        doReturn(Optional.of(testQuery)).when(queryRepository).findById(testQueryId);
+        doThrow(JsonProcessingException.class).when(jsonUtil).readValue(testQueryContent.getQueryContent(),
+                StructuredQuery.class);
+
+        var queryDispatcher = createQueryDispatcher(List.of());
+        StepVerifier.create(queryDispatcher.dispatchEnqueuedQuery(testQueryId))
+                .expectError(QueryDispatchException.class)
+                .verify();
+    }
+
+    @Test
+    public void testDispatchEnqueuedQuery_FailsWhenQueryCannotGetTranslated() throws JsonProcessingException,
+            QueryTranslationException {
+        var testQueryId = 99999L;
+        var testQuery = new Query();
+        testQuery.setId(testQueryId);
+        var structuredQuery = new StructuredQuery();
+        var testQueryContent = new QueryContent(jsonUtil.writeValueAsString(structuredQuery));
+        testQuery.setQueryContent(testQueryContent);
+
+        doReturn(Optional.of(testQuery)).when(queryRepository).findById(testQueryId);
+        doReturn(structuredQuery).when(jsonUtil).readValue(testQueryContent.getQueryContent(), StructuredQuery.class);
+        doThrow(QueryTranslationException.class).when(queryTranslationComponent).translate(structuredQuery);
+
+
+        var queryDispatcher = createQueryDispatcher(List.of());
+        StepVerifier.create(queryDispatcher.dispatchEnqueuedQuery(testQueryId))
+                .expectError(QueryDispatchException.class)
+                .verify();
+    }
+
+    @Test
+    public void testDispatchEnqueuedQuery_FailsOnBrokerQueryCreationError() throws IOException,
+            QueryTranslationException {
+        var testQueryId = 99999L;
+        var testQuery = new Query();
+        testQuery.setId(testQueryId);
+        var structuredQuery = new StructuredQuery();
+        var testQueryContent = new QueryContent(jsonUtil.writeValueAsString(structuredQuery));
+        testQuery.setQueryContent(testQueryContent);
+
+        var failingBrokerClient = mock(BrokerClient.class);
+
+        doReturn(Optional.of(testQuery)).when(queryRepository).findById(testQueryId);
+        doReturn(structuredQuery).when(jsonUtil).readValue(testQueryContent.getQueryContent(), StructuredQuery.class);
+        doReturn(Map.of()).when(queryTranslationComponent).translate(structuredQuery);
+        doThrow(IOException.class).when(failingBrokerClient).createQuery(testQueryId);
+
+        var queryDispatcher = createQueryDispatcher(List.of(failingBrokerClient));
+        StepVerifier.create(queryDispatcher.dispatchEnqueuedQuery(testQueryId))
+                .expectError(QueryDispatchException.class)
+                .verify();
+    }
+
+    @Test
+    public void testDispatchEnqueuedQuery_FailsOnBrokerPublishError() throws IOException, QueryTranslationException,
+            QueryNotFoundException {
+        var testQueryId = 99999L;
+        var testQuery = new Query();
+        testQuery.setId(testQueryId);
+        var structuredQuery = new StructuredQuery();
+        structuredQuery.setVersion(URI.create("https://to.be.decided/schema"));
+        structuredQuery.setDisplay("Test");
+
+        var testQueryContent = new QueryContent(jsonUtil.writeValueAsString(structuredQuery));
+        testQuery.setQueryContent(testQueryContent);
+        var translationResult = Map.of(QueryMediaType.STRUCTURED_QUERY, testQueryContent.getQueryContent());
+
+        var failingBrokerClient = mock(BrokerClient.class);
+
+        doReturn(Optional.of(testQuery)).when(queryRepository).findById(testQueryId);
+        doReturn(structuredQuery).when(jsonUtil).readValue(testQueryContent.getQueryContent(), StructuredQuery.class);
+        doReturn(translationResult).when(queryTranslationComponent).translate(structuredQuery);
+        doReturn("1").when(failingBrokerClient).createQuery(testQueryId);
+        doThrow(IOException.class).when(failingBrokerClient).publishQuery("1");
+
+        var queryDispatcher = createQueryDispatcher(List.of(failingBrokerClient));
+        StepVerifier.create(queryDispatcher.dispatchEnqueuedQuery(testQueryId))
+                .expectError(QueryDispatchException.class)
+                .verify();
+    }
+
+    @Test
+    public void testDispatchEnqueuedQuery_DoesNotFailOnSingleBrokerError() throws IOException, QueryNotFoundException {
+        var failingBrokerClient = mock(BrokerClient.class);
+        var succeedingBrokerClient = mock(BrokerClient.class);
+        var queryDispatcher = createQueryDispatcher(List.of(failingBrokerClient, succeedingBrokerClient));
+
+        var testQueryId = 99999L;
+        var testQuery = new Query();
+        testQuery.setId(testQueryId);
+        var testQueryContent = new QueryContent(jsonUtil.writeValueAsString(new StructuredQuery()));
+        testQuery.setQueryContent(testQueryContent);
+
+        doReturn(Optional.of(testQuery)).when(queryRepository).findById(testQueryId);
+        doReturn("1").when(failingBrokerClient).createQuery(testQueryId);
+        doReturn("1").when(succeedingBrokerClient).createQuery(testQueryId);
+        doThrow(IOException.class).when(failingBrokerClient).publishQuery(anyString());
+
+
+        StepVerifier.create(queryDispatcher.dispatchEnqueuedQuery(testQueryId))
+                .expectComplete()
+                .verify();
+        verify(failingBrokerClient, times(1)).publishQuery("1");
+        verify(succeedingBrokerClient, times(1)).publishQuery("1");
+    }
+
+    @Test
+    public void testDispatchEnqueuedQuery_DoesFailIfAllBrokersFail() throws IOException, QueryNotFoundException {
+        var failingBrokerClient = mock(BrokerClient.class);
+        var anotherFailingBrokerClient = mock(BrokerClient.class);
+        var queryDispatcher = createQueryDispatcher(List.of(failingBrokerClient,
+                anotherFailingBrokerClient));
+
+        var testQueryId = 99999L;
+        var testQuery = new Query();
+        testQuery.setId(testQueryId);
+        var testQueryContent = new QueryContent(jsonUtil.writeValueAsString(new StructuredQuery()));
+        testQuery.setQueryContent(testQueryContent);
+
+        doReturn(Optional.of(testQuery)).when(queryRepository).findById(testQueryId);
+        doReturn("1").when(failingBrokerClient).createQuery(testQueryId);
+        doReturn("1").when(anotherFailingBrokerClient).createQuery(testQueryId);
+        doThrow(IOException.class).when(failingBrokerClient).publishQuery(anyString());
+        doThrow(IOException.class).when(anotherFailingBrokerClient).publishQuery(anyString());
+
+        StepVerifier.create(queryDispatcher.dispatchEnqueuedQuery(testQueryId))
+                .expectError(QueryDispatchException.class)
+                .verify();
+        verify(failingBrokerClient, times(1)).publishQuery("1");
+        verify(anotherFailingBrokerClient, times(1)).publishQuery("1");
+    }
+}

--- a/src/test/java/de/numcodex/feasibility_gui_backend/query/v2/QueryHandlerRestControllerIT.java
+++ b/src/test/java/de/numcodex/feasibility_gui_backend/query/v2/QueryHandlerRestControllerIT.java
@@ -1,25 +1,13 @@
 package de.numcodex.feasibility_gui_backend.query.v2;
 
-import static org.mockito.ArgumentMatchers.any;
-import static org.mockito.ArgumentMatchers.eq;
-import static org.mockito.Mockito.when;
-import static org.springframework.http.HttpHeaders.LOCATION;
-import static org.springframework.http.MediaType.APPLICATION_JSON;
-import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
-import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.header;
-import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
-
 import com.fasterxml.jackson.databind.ObjectMapper;
 import de.numcodex.feasibility_gui_backend.common.api.Criterion;
 import de.numcodex.feasibility_gui_backend.common.api.TermCode;
 import de.numcodex.feasibility_gui_backend.query.QueryHandlerService;
-import de.numcodex.feasibility_gui_backend.query.api.QueryTemplate;
 import de.numcodex.feasibility_gui_backend.query.api.StructuredQuery;
 import de.numcodex.feasibility_gui_backend.query.api.validation.StructuredQueryValidatorSpringConfig;
+import de.numcodex.feasibility_gui_backend.query.dispatch.QueryDispatchException;
 import de.numcodex.feasibility_gui_backend.terminology.validation.TermCodeValidation;
-import java.net.URI;
-import java.util.ArrayList;
-import java.util.List;
 import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -27,9 +15,23 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
 import org.springframework.boot.test.mock.mockito.MockBean;
 import org.springframework.context.annotation.Import;
+import org.springframework.http.HttpStatus;
 import org.springframework.security.test.context.support.WithMockUser;
 import org.springframework.test.context.junit.jupiter.SpringExtension;
 import org.springframework.test.web.servlet.MockMvc;
+import reactor.core.publisher.Mono;
+
+import java.net.URI;
+import java.util.ArrayList;
+import java.util.List;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.doReturn;
+import static org.springframework.http.MediaType.APPLICATION_JSON;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.asyncDispatch;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
 
 @Tag("query")
 @ExtendWith(SpringExtension.class)
@@ -37,8 +39,7 @@ import org.springframework.test.web.servlet.MockMvc;
 @WebMvcTest(
         controllers = QueryHandlerRestController.class,
         properties = {
-                "app.enableQueryValidation=true",
-                "keycloak.enabled=false"
+                "app.enableQueryValidation=true"
         }
 )
 @SuppressWarnings("NewClassNamingConvention")
@@ -68,7 +69,7 @@ public class QueryHandlerRestControllerIT {
     }
 
     @Test
-    @WithMockUser(roles = "FEASIBILITY_TEST_USER")
+    @WithMockUser(roles = "FEASIBILITY_TEST_USER", username = "test")
     public void testRunQueryEndpoint_SucceedsOnValidStructuredQueryWith201() throws Exception {
         var termCode = new TermCode();
         termCode.setCode("LL2191-6");
@@ -84,13 +85,50 @@ public class QueryHandlerRestControllerIT {
         testQuery.setDisplay("foo");
         testQuery.setVersion(URI.create("http://to_be_decided.com/draft-2/schema#"));
 
-        when(queryHandlerService.runQuery(any(StructuredQuery.class), eq("test"))).thenReturn(1L);
-        when(termCodeValidation.getInvalidTermCodes(any(StructuredQuery.class))).thenReturn(new ArrayList<>());
+        doReturn(Mono.just(1L)).when(queryHandlerService).runQuery(any(StructuredQuery.class), eq("test"));
+        doReturn(List.of()).when(termCodeValidation).getInvalidTermCodes(any(StructuredQuery.class));
 
-        mockMvc.perform(post(URI.create("/api/v2/query"))
+        var mvcResult = mockMvc.perform(post(URI.create("/api/v2/query"))
                         .contentType(APPLICATION_JSON)
                         .content(jsonUtil.writeValueAsString(testQuery)))
+                .andExpect(request().asyncStarted())
+                .andReturn();
+
+        mockMvc.perform(asyncDispatch(mvcResult))
                 .andExpect(status().isCreated())
-                .andExpect(header().string(LOCATION, "/api/v2/query/0"));
+                .andExpect(header().exists("location"))
+                .andExpect(header().string("location", "/api/v2/query/1"));
+    }
+
+    @Test
+    @WithMockUser(roles = "FEASIBILITY_TEST_USER", username = "test")
+    public void testRunQueryEndpoint_FailsOnDownstreamServiceError() throws Exception {
+        var termCode = new TermCode();
+        termCode.setCode("LL2191-6");
+        termCode.setSystem("http://loinc.org");
+        termCode.setDisplay("Geschlecht");
+
+        var inclusionCriterion = new Criterion();
+        inclusionCriterion.setTermCodes(new ArrayList<>(List.of(termCode)));
+
+        var testQuery = new StructuredQuery();
+        testQuery.setInclusionCriteria(List.of(List.of(inclusionCriterion)));
+        testQuery.setExclusionCriteria(List.of());
+        testQuery.setDisplay("foo");
+        testQuery.setVersion(URI.create("http://to_be_decided.com/draft-2/schema#"));
+
+        var dispatchError = new QueryDispatchException("something went wrong");
+
+        doReturn(Mono.error(dispatchError)).when(queryHandlerService).runQuery(any(StructuredQuery.class), eq("test"));
+        doReturn(List.of()).when(termCodeValidation).getInvalidTermCodes(any(StructuredQuery.class));
+
+        var mvcResult = mockMvc.perform(post(URI.create("/api/v2/query"))
+                        .contentType(APPLICATION_JSON)
+                        .content(jsonUtil.writeValueAsString(testQuery)))
+                .andExpect(request().asyncStarted())
+                .andReturn();
+
+        mockMvc.perform(asyncDispatch(mvcResult))
+                .andExpect(status().is(HttpStatus.INTERNAL_SERVER_ERROR.value()));
     }
 }


### PR DESCRIPTION
Resolves #25.

Allows dispatching queries via brokers in an asynchronous fashion. Dispatch is done on a single thread since transactional database operations are involved. The reason for this is that Spring's transaction propagation has to be respected. Using multiple threads breaks this because transaction information is stored within thread local variables and thus cannot be shared between threads.

The goal for this implementation is that individual brokers can fail without affecting those that ran sucessfully. This gives the UI (or any other client) the possibility to request at least partial results.
A request will only ever fail if all participating brokers fail to publish a query.