### PR TITLE
#34 - check security config

### DIFF
--- a/src/main/java/de/numcodex/feasibility_gui_backend/config/SecurityConfig.java
+++ b/src/main/java/de/numcodex/feasibility_gui_backend/config/SecurityConfig.java
@@ -60,6 +60,7 @@ class SecurityConfig extends KeycloakWebSecurityConfigurerAdapter {
 
     http.authorizeRequests()
         .antMatchers("/api/v1/**").hasRole(keycloakAllowedRole)
+        .antMatchers("/api/v2/terminology/**").hasRole(keycloakAllowedRole)
         .antMatchers("/api/v2/query").hasRole(keycloakAllowedRole)
         .antMatchers("/api/v2/query/{id:\\d+}/saved").hasRole(keycloakAllowedRole)
         .antMatchers("/api/v2/query/by-user/{id:[\\w-]+}").hasRole(keycloakAdminRole)
@@ -67,8 +68,7 @@ class SecurityConfig extends KeycloakWebSecurityConfigurerAdapter {
         .antMatchers("/api/v2/query/{id:\\d+}/result/detailed").hasRole(keycloakAdminRole)
         .antMatchers("/api/v2/query/{id:\\d+}/result").hasAnyRole(keycloakAdminRole, keycloakAllowedRole)
         .antMatchers("/api/v2/query/{id:\\d+}/content").hasAnyRole(keycloakAdminRole, keycloakAllowedRole)
-        .anyRequest()
-        .permitAll()
+        .anyRequest().authenticated()
         .and()
         .csrf().disable();
   }

--- a/src/main/java/de/numcodex/feasibility_gui_backend/config/SecurityConfig.java
+++ b/src/main/java/de/numcodex/feasibility_gui_backend/config/SecurityConfig.java
@@ -59,6 +59,7 @@ class SecurityConfig extends KeycloakWebSecurityConfigurerAdapter {
         .sessionCreationPolicy(SessionCreationPolicy.STATELESS);
 
     http.authorizeRequests()
+        .antMatchers("/actuator/health").permitAll()
         .antMatchers("/api/v1/**").hasRole(keycloakAllowedRole)
         .antMatchers("/api/v2/terminology/**").hasRole(keycloakAllowedRole)
         .antMatchers("/api/v2/query").hasRole(keycloakAllowedRole)

--- a/src/main/java/de/numcodex/feasibility_gui_backend/query/v2/QueryHandlerRestController.java
+++ b/src/main/java/de/numcodex/feasibility_gui_backend/query/v2/QueryHandlerRestController.java
@@ -66,11 +66,9 @@ public class QueryHandlerRestController {
 
     Long amountOfQueriesByUserAndInterval = queryHandlerService.getAmountOfQueriesByUserAndInterval(
         principal.getName(), nQueriesPerMinute);
-    log.error("amount: " + amountOfQueriesByUserAndInterval);
     if (nQueriesAmount <= amountOfQueriesByUserAndInterval) {
       Long retryAfter = queryHandlerService.getRetryAfterTime(principal.getName(),
           nQueriesAmount - 1, nQueriesPerMinute);
-      log.error("retry after: " + retryAfter);
       HttpHeaders httpHeaders = new HttpHeaders();
       httpHeaders.add(HttpHeaders.RETRY_AFTER, Long.toString(retryAfter));
       return Mono.just(new ResponseEntity<>(httpHeaders, HttpStatus.TOO_MANY_REQUESTS));


### PR DESCRIPTION
Set default security config to authenticated, allowing no endpoints to be used without bein authenticated. One exception is the /actuator/health endpoint which is open without authentication.