### PR TITLE
Support DSF Feasibility Plugin v0.4.0

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>org.springframework.boot</groupId>
     <artifactId>spring-boot-starter-parent</artifactId>
-    <version>2.7.3</version>
+    <version>2.7.5</version>
     <relativePath /> <!-- lookup parent from repository -->
   </parent>
   <groupId>de.medizininformatik-initiative</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -137,10 +137,26 @@
       <version>1.3.2</version>
     </dependency>
 
+    <!--
+      This is for fixing an RCE vulnerability in commons-text <1.10.0. The dependency comes with the
+      dsf-fhir-webservice-client which cannot update the transitive dependency itself due to breaking
+      changes.
+    -->
+    <dependency>
+      <groupId>org.apache.commons</groupId>
+      <artifactId>commons-text</artifactId>
+      <version>1.10.0</version>
+    </dependency>
     <dependency>
       <groupId>org.highmed.dsf</groupId>
       <artifactId>dsf-fhir-webservice-client</artifactId>
       <version>0.9.0</version>
+      <exclusions>
+        <exclusion>
+          <groupId>org.apache.commons</groupId>
+          <artifactId>commons-text</artifactId>
+        </exclusion>
+      </exclusions>
     </dependency>
 
     <dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -140,19 +140,19 @@
     <dependency>
       <groupId>org.highmed.dsf</groupId>
       <artifactId>dsf-fhir-webservice-client</artifactId>
-      <version>0.7.0</version>
+      <version>0.9.0</version>
     </dependency>
 
     <dependency>
       <groupId>org.highmed.dsf</groupId>
       <artifactId>dsf-fhir-websocket-client</artifactId>
-      <version>0.7.0</version>
+      <version>0.9.0</version>
     </dependency>
 
     <dependency>
       <groupId>org.highmed.dsf</groupId>
       <artifactId>dsf-fhir-rest-adapter</artifactId>
-      <version>0.7.0</version>
+      <version>0.9.0</version>
     </dependency>
 
     <dependency>

--- a/src/main/java/de/numcodex/feasibility_gui_backend/query/broker/dsf/DSFQueryManager.java
+++ b/src/main/java/de/numcodex/feasibility_gui_backend/query/broker/dsf/DSFQueryManager.java
@@ -28,7 +28,7 @@ import static org.hl7.fhir.r4.model.Task.TaskStatus.REQUESTED;
  */
 class DSFQueryManager implements QueryManager {
 
-    private static final String INSTANTIATE_URI = "http://medizininformatik-initiative.de/bpe/Process/feasibilityRequest/0.3.0";
+    private static final String INSTANTIATE_URI = "http://medizininformatik-initiative.de/bpe/Process/feasibilityRequest/0.4.0";
     private static final String REQUEST_PROFILE = "http://medizininformatik-initiative.de/fhir/StructureDefinition/feasibility-task-request";
     private static final String MEASURE_PROFILE = "http://medizininformatik-initiative.de/fhir/StructureDefinition/feasibility-measure";
     private static final String LIBRARY_PROFILE = "http://medizininformatik-initiative.de/fhir/StructureDefinition/feasibility-library";

--- a/src/main/java/de/numcodex/feasibility_gui_backend/query/broker/dsf/DSFQueryResultHandler.java
+++ b/src/main/java/de/numcodex/feasibility_gui_backend/query/broker/dsf/DSFQueryResultHandler.java
@@ -13,7 +13,7 @@ import java.util.Optional;
 @Slf4j
 class DSFQueryResultHandler {
 
-    private static final String SINGLE_DIC_QUERY_RESULT_PROFILE = "http://medizininformatik-initiative.de/fhir/StructureDefinition/feasibility-task-single-dic-result|0.3.0";
+    private static final String SINGLE_DIC_QUERY_RESULT_PROFILE = "http://medizininformatik-initiative.de/fhir/StructureDefinition/feasibility-task-single-dic-result|0.4.0";
     private static final String CODE_SYSTEM_FEASIBILITY = "http://medizininformatik-initiative.de/fhir/CodeSystem/feasibility";
     private static final String CODE_SYSTEM_FEASIBILITY_VALUE_MEASURE_REPORT_REF = "measure-report-reference";
     private static final String CODE_SYSTEM_BPMN_MESSAGE = "http://highmed.org/fhir/CodeSystem/bpmn-message";

--- a/src/test/java/de/numcodex/feasibility_gui_backend/query/broker/dsf/DSFQueryManagerTest.java
+++ b/src/test/java/de/numcodex/feasibility_gui_backend/query/broker/dsf/DSFQueryManagerTest.java
@@ -145,7 +145,7 @@ public class DSFQueryManagerTest {
 
         assertEquals(businessKey, queryId);
         assertNotNull(library.getName());
-        assertEquals("http://medizininformatik-initiative.de/bpe/Process/feasibilityRequest/0.3.0", task.getInstantiatesUri());
+        assertEquals("http://medizininformatik-initiative.de/bpe/Process/feasibilityRequest/0.4.0", task.getInstantiatesUri());
         assertEquals(1, task.getMeta().getProfile().stream().filter(p -> p.getValueAsString()
                         .equals("http://medizininformatik-initiative.de/fhir/StructureDefinition/feasibility-task-request"))
                 .count());

--- a/src/test/java/de/numcodex/feasibility_gui_backend/query/broker/dsf/DSFQueryResultCollectorIT.java
+++ b/src/test/java/de/numcodex/feasibility_gui_backend/query/broker/dsf/DSFQueryResultCollectorIT.java
@@ -31,7 +31,7 @@ import static org.mockito.Mockito.when;
 @SuppressWarnings("NewClassNamingConvention")
 public class DSFQueryResultCollectorIT {
 
-    private static final String SINGLE_DIC_RESULT_PROFILE = "http://medizininformatik-initiative.de/fhir/StructureDefinition/feasibility-task-single-dic-result|0.3.0";
+    private static final String SINGLE_DIC_RESULT_PROFILE = "http://medizininformatik-initiative.de/fhir/StructureDefinition/feasibility-task-single-dic-result|0.4.0";
 
     @Mock
     private DSFBrokerClient brokerClient;
@@ -60,7 +60,7 @@ public class DSFQueryResultCollectorIT {
                 .setStatus(COMPLETED)
                 .setIntent(ORDER)
                 .setAuthoredOn(new Date())
-                .setInstantiatesUri("http://highmed.org/bpe/Process/feasibilityRequest/0.3.0");
+                .setInstantiatesUri("http://highmed.org/bpe/Process/feasibilityRequest/0.4.0");
 
         task.getRequester()
                 .setType("Organization")

--- a/src/test/java/de/numcodex/feasibility_gui_backend/query/broker/dsf/DSFQueryResultHandlerTest.java
+++ b/src/test/java/de/numcodex/feasibility_gui_backend/query/broker/dsf/DSFQueryResultHandlerTest.java
@@ -55,7 +55,7 @@ public class DSFQueryResultHandlerTest {
                 .setIntent(ORDER)
                 .setRequester(dicOrganizationRef)
                 .setRestriction(new TaskRestrictionComponent().addRecipient(zarsOrganizationRef));
-        task.getMeta().addProfile("http://medizininformatik-initiative.de/fhir/StructureDefinition/feasibility-task-single-dic-result|0.3.0");
+        task.getMeta().addProfile("http://medizininformatik-initiative.de/fhir/StructureDefinition/feasibility-task-single-dic-result|0.4.0");
 
         task.addInput()
                 .setType(new CodeableConcept()
@@ -88,7 +88,7 @@ public class DSFQueryResultHandlerTest {
                 .setIntent(ORDER)
                 .setRequester(dicOrganizationRef)
                 .setRestriction(new TaskRestrictionComponent().addRecipient(zarsOrganizationRef));
-        task.getMeta().addProfile("http://medizininformatik-initiative.de/fhir/StructureDefinition/feasibility-task-single-dic-result|0.3.0");
+        task.getMeta().addProfile("http://medizininformatik-initiative.de/fhir/StructureDefinition/feasibility-task-single-dic-result|0.4.0");
 
         task.addInput()
                 .setType(new CodeableConcept()


### PR DESCRIPTION
Resolves #36 

This PR also bumps Spring to a new bugfix version and takes care of a [CVE](https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2022-42889) that allows for RCEs.

The `commons-text` dependency has been replaced in order to tackle the CVE. This is a transitive dependency used by `dsf-fhir-webservice-client`. After talking to the devs it was clear that they cannot bump the version since that would break major parts of the DSF framework. Thus, adjustments have been made in this project (reasoning also added as a comment in `pom.xml`).