### PR TITLE
#66 - Fix Potential Bug in QueryHandlerService.getAuthorId Able to Return Null

### DIFF
--- a/src/main/java/de/numcodex/feasibility_gui_backend/query/QueryHandlerService.java
+++ b/src/main/java/de/numcodex/feasibility_gui_backend/query/QueryHandlerService.java
@@ -181,8 +181,8 @@ public class QueryHandlerService {
         return queries.orElseGet(ArrayList::new);
     }
 
-    public String getAuthorId(Long queryId) {
-        return queryRepository.getAuthor(queryId).orElse(null);
+    public String getAuthorId(Long queryId) throws QueryNotFoundException {
+        return queryRepository.getAuthor(queryId).orElseThrow(QueryNotFoundException::new);
     }
 
     public List<QueryListEntry> convertQueriesToQueryListEntries(List<de.numcodex.feasibility_gui_backend.query.persistence.Query> queryList) {

--- a/src/main/java/de/numcodex/feasibility_gui_backend/query/QueryNotFoundException.java
+++ b/src/main/java/de/numcodex/feasibility_gui_backend/query/QueryNotFoundException.java
@@ -1,0 +1,7 @@
+package de.numcodex.feasibility_gui_backend.query;
+
+public class QueryNotFoundException extends Exception {
+
+  public QueryNotFoundException() {
+  }
+}

--- a/src/main/java/de/numcodex/feasibility_gui_backend/query/v1/QueryHandlerRestController.java
+++ b/src/main/java/de/numcodex/feasibility_gui_backend/query/v1/QueryHandlerRestController.java
@@ -2,6 +2,7 @@ package de.numcodex.feasibility_gui_backend.query.v1;
 
 import de.numcodex.feasibility_gui_backend.query.QueryHandlerService;
 import de.numcodex.feasibility_gui_backend.query.QueryHandlerService.ResultDetail;
+import de.numcodex.feasibility_gui_backend.query.QueryNotFoundException;
 import de.numcodex.feasibility_gui_backend.query.api.StructuredQuery;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Value;
@@ -92,7 +93,14 @@ public class QueryHandlerRestController {
   public ResponseEntity<Object> getQueryResult(@PathVariable("id") Long queryId,
       Authentication authentication) {
 
-    if (queryHandlerService.getAuthorId(queryId).equalsIgnoreCase(authentication.getName())) {
+    String authorId;
+    try {
+      authorId = queryHandlerService.getAuthorId(queryId);
+    } catch (QueryNotFoundException e) {
+      return new ResponseEntity<>(HttpStatus.NOT_FOUND);
+    }
+
+    if (authorId.equalsIgnoreCase(authentication.getName())) {
       return new ResponseEntity<>(
           queryHandlerService.getQueryResult(queryId, ResultDetail.DETAILED_OBFUSCATED),
           HttpStatus.OK);

--- a/src/test/java/de/numcodex/feasibility_gui_backend/query/QueryHandlerServiceIT.java
+++ b/src/test/java/de/numcodex/feasibility_gui_backend/query/QueryHandlerServiceIT.java
@@ -29,6 +29,7 @@ import static de.numcodex.feasibility_gui_backend.query.QueryHandlerService.Resu
 import static de.numcodex.feasibility_gui_backend.query.persistence.ResultType.ERROR;
 import static de.numcodex.feasibility_gui_backend.query.persistence.ResultType.SUCCESS;
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 
 @Tag("query")
 @Tag("handler")
@@ -155,5 +156,11 @@ public class QueryHandlerServiceIT {
             .hasSize(2)
             .contains(QueryResultLine.builder().siteName(SITE_NAME_1).numberOfPatients(10L).build(),
                 QueryResultLine.builder().siteName(SITE_NAME_2).numberOfPatients(20L).build());
+    }
+
+    @Test
+    public void testGetAuthorId_UnknownQueryIdThrows() {
+        assertThrows(QueryNotFoundException.class,
+            () -> queryHandlerService.getAuthorId(UNKNOWN_QUERY_ID));
     }
 }


### PR DESCRIPTION
- instead of returning null when the author of a non-existing query is requested, throw an exception
- check for this exception in calling controllers and return 404 in this case
- add test for this case