### PR TITLE
Switch to Non Focal Based Docker Image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM eclipse-temurin:17-jre-focal
+FROM eclipse-temurin:17-jre
 
 RUN apt update -yqq && apt upgrade -yqq
 


### PR DESCRIPTION
We have 64 CVE's with the Focal image. We also don't need to support older Docker infrastructures anymore.