### PR TITLE
#68 - limit requesting of detailed results per user

### DIFF
--- a/src/main/java/de/numcodex/feasibility_gui_backend/query/ratelimiting/RateLimitingInterceptor.java
+++ b/src/main/java/de/numcodex/feasibility_gui_backend/query/ratelimiting/RateLimitingInterceptor.java
@@ -1,5 +1,6 @@
 package de.numcodex.feasibility_gui_backend.query.ratelimiting;
 
+import de.numcodex.feasibility_gui_backend.config.WebSecurityConfig;
 import io.github.bucket4j.Bucket;
 import io.github.bucket4j.ConsumptionProbe;
 import jakarta.servlet.http.HttpServletRequest;
@@ -21,6 +22,9 @@ public class RateLimitingInterceptor implements HandlerInterceptor {
 
   private static final String HEADER_LIMIT_REMAINING = "X-Rate-Limit-Remaining";
   private static final String HEADER_RETRY_AFTER = "X-Rate-Limit-Retry-After-Seconds";
+
+  private static final String HEADER_LIMIT_REMAINING_DETAILED_OBFUSCATED_RESULTS = "X-Rate-Limit-Detailed-Obfuscated-Results-Remaining";
+  private static final String HEADER_RETRY_AFTER_DETAILED_OBFUSCATED_RESULTS = "X-Rate-Limit-Detailed-Obfuscated-Results-Retry-After-Seconds";
   private final RateLimitingService rateLimitingService;
 
   private final AuthenticationHelper authenticationHelper;
@@ -54,13 +58,28 @@ public class RateLimitingInterceptor implements HandlerInterceptor {
       return false;
     }
 
-    Bucket tokenBucket = rateLimitingService.resolveBucket(authentication.getName());
-    ConsumptionProbe probe = tokenBucket.tryConsumeAndReturnRemaining(1);
-    if (probe.isConsumed()) {
-      response.addHeader(HEADER_LIMIT_REMAINING, Long.toString(probe.getRemainingTokens()));
+    Bucket anyResultTokenBucket = rateLimitingService.resolveAnyResultBucket(authentication.getName());
+    ConsumptionProbe anyResultProbe = anyResultTokenBucket.tryConsumeAndReturnRemaining(1);
+    if (anyResultProbe.isConsumed()) {
+      if (request.getRequestURI().endsWith(WebSecurityConfig.PATH_DETAILED_OBFUSCATED_RESULT)) {
+        Bucket detailedObfuscatedResultTokenBucket = rateLimitingService.resolveDetailedObfuscatedResultBucket(
+            authentication.getName());
+        ConsumptionProbe detailedObfuscatedResultProbe = detailedObfuscatedResultTokenBucket.tryConsumeAndReturnRemaining(
+            1);
+        if (detailedObfuscatedResultProbe.isConsumed()) {
+          response.addHeader(HEADER_LIMIT_REMAINING_DETAILED_OBFUSCATED_RESULTS, Long.toString(detailedObfuscatedResultProbe.getRemainingTokens()));
+        } else {
+          long waitForRefill = detailedObfuscatedResultProbe.getNanosToWaitForRefill() / 1_000_000_000;
+          response.addHeader(HEADER_RETRY_AFTER_DETAILED_OBFUSCATED_RESULTS, Long.toString(waitForRefill));
+          response.sendError(HttpStatus.TOO_MANY_REQUESTS.value(),
+              "You have exhausted your Request Quota for detailed obfuscated results");
+          return false;
+        }
+      }
+      response.addHeader(HEADER_LIMIT_REMAINING, Long.toString(anyResultProbe.getRemainingTokens()));
       return true;
     } else {
-      long waitForRefill = probe.getNanosToWaitForRefill() / 1_000_000_000;
+      long waitForRefill = anyResultProbe.getNanosToWaitForRefill() / 1_000_000_000;
       response.addHeader(HEADER_RETRY_AFTER, Long.toString(waitForRefill));
       response.sendError(HttpStatus.TOO_MANY_REQUESTS.value(),
           "You have exhausted your API Request Quota");

--- a/src/main/java/de/numcodex/feasibility_gui_backend/query/ratelimiting/RateLimitingServiceSpringConfig.java
+++ b/src/main/java/de/numcodex/feasibility_gui_backend/query/ratelimiting/RateLimitingServiceSpringConfig.java
@@ -12,8 +12,14 @@ public class RateLimitingServiceSpringConfig {
 
   @Bean
   public RateLimitingService createRateLimitingService(
-      @Value("${app.privacy.quota.read.any.pollingIntervalSeconds}") int pollingIntervalSeconds) {
-    log.info("Create RateLimitingService with interval of {} seconds", pollingIntervalSeconds);
-    return new RateLimitingService(Duration.ofSeconds(pollingIntervalSeconds));
+      @Value("${app.privacy.quota.read.any.pollingIntervalSeconds}") int pollingIntervalSeconds,
+      @Value("${app.privacy.quota.read.detailedObfuscated.amount}") int detailedObfuscatedAmount,
+      @Value("${app.privacy.quota.read.detailedObfuscated.intervalMinutes}") int detailedObfuscatedIntervalMinutes) {
+
+    log.info(
+        "Create RateLimitingService with interval of {} seconds for any result endpoint and {} allowed requests to detailed obfuscated result per {} minutes",
+        pollingIntervalSeconds, detailedObfuscatedAmount, detailedObfuscatedIntervalMinutes);
+    return new RateLimitingService(Duration.ofSeconds(pollingIntervalSeconds),
+        detailedObfuscatedAmount, Duration.ofMinutes(detailedObfuscatedIntervalMinutes));
   }
 }

--- a/src/main/java/de/numcodex/feasibility_gui_backend/query/ratelimiting/RateLimitingServiceSpringConfig.java
+++ b/src/main/java/de/numcodex/feasibility_gui_backend/query/ratelimiting/RateLimitingServiceSpringConfig.java
@@ -14,12 +14,12 @@ public class RateLimitingServiceSpringConfig {
   public RateLimitingService createRateLimitingService(
       @Value("${app.privacy.quota.read.any.pollingIntervalSeconds}") int pollingIntervalSeconds,
       @Value("${app.privacy.quota.read.detailedObfuscated.amount}") int detailedObfuscatedAmount,
-      @Value("${app.privacy.quota.read.detailedObfuscated.intervalMinutes}") int detailedObfuscatedIntervalMinutes) {
+      @Value("${app.privacy.quota.read.detailedObfuscated.intervalSeconds}") int detailedObfuscatedIntervalSeconds) {
 
     log.info(
-        "Create RateLimitingService with interval of {} seconds for any result endpoint and {} allowed requests to detailed obfuscated result per {} minutes",
-        pollingIntervalSeconds, detailedObfuscatedAmount, detailedObfuscatedIntervalMinutes);
+        "Create RateLimitingService with interval of {} seconds for any result endpoint and {} allowed requests to detailed obfuscated result per {} seconds",
+        pollingIntervalSeconds, detailedObfuscatedAmount, detailedObfuscatedIntervalSeconds);
     return new RateLimitingService(Duration.ofSeconds(pollingIntervalSeconds),
-        detailedObfuscatedAmount, Duration.ofMinutes(detailedObfuscatedIntervalMinutes));
+        detailedObfuscatedAmount, Duration.ofSeconds(detailedObfuscatedIntervalSeconds));
   }
 }

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -91,6 +91,9 @@ app:
       read:
         any:
           pollingIntervalSeconds: ${PRIVACY_QUOTA_READ_ANY_POLLINGINTERVALSECONDS:10}
+        detailedObfuscated:
+          amount: ${PRIVACY_QUOTA_READ_DETAILEDOBFUSCATED_AMOUNT:3}
+          intervalMinutes: ${PRIVACY_QUOTA_READ_DETAILEDOBFUSCATED_INTERVALMINUTES:120}
 
 logging:
   level:

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -93,7 +93,7 @@ app:
           pollingIntervalSeconds: ${PRIVACY_QUOTA_READ_ANY_POLLINGINTERVALSECONDS:10}
         detailedObfuscated:
           amount: ${PRIVACY_QUOTA_READ_DETAILEDOBFUSCATED_AMOUNT:3}
-          intervalMinutes: ${PRIVACY_QUOTA_READ_DETAILEDOBFUSCATED_INTERVALMINUTES:120}
+          intervalSeconds: ${PRIVACY_QUOTA_READ_DETAILEDOBFUSCATED_INTERVALSECONDS:7200}
 
 logging:
   level:

--- a/src/test/java/de/numcodex/feasibility_gui_backend/query/ratelimiting/RateLimitingServiceTest.java
+++ b/src/test/java/de/numcodex/feasibility_gui_backend/query/ratelimiting/RateLimitingServiceTest.java
@@ -16,27 +16,30 @@ import static org.junit.jupiter.api.Assertions.*;
 public class RateLimitingServiceTest {
 
   private final Duration interval = Duration.ofSeconds(1);
+  private final int amountDetailedObfuscated = 2;
+  private final Duration intervalDetailedObfuscated = Duration.ofSeconds(2);
 
   private RateLimitingService rateLimitingService;
 
   @BeforeEach
   void setUp() {
-    this.rateLimitingService = new RateLimitingService(interval);
+    this.rateLimitingService = new RateLimitingService(interval, amountDetailedObfuscated,
+        intervalDetailedObfuscated);
   }
 
   @Test
   void testResolveBucket() {
-    Bucket bucketSomeone = rateLimitingService.resolveBucket("someone");
+    Bucket bucketSomeone = rateLimitingService.resolveAnyResultBucket("someone");
     assertNotNull(bucketSomeone);
-    Bucket bucketSomeoneElse = rateLimitingService.resolveBucket("someone-else");
+    Bucket bucketSomeoneElse = rateLimitingService.resolveAnyResultBucket("someone-else");
     assertNotNull(bucketSomeoneElse);
     assertNotEquals(bucketSomeone, bucketSomeoneElse);
-    assertEquals(bucketSomeone, rateLimitingService.resolveBucket("someone"));
+    assertEquals(bucketSomeone, rateLimitingService.resolveAnyResultBucket("someone"));
   }
 
   @Test
   void testResolveBucketRefill() throws InterruptedException {
-    Bucket bucketSomeone = rateLimitingService.resolveBucket("someone");
+    Bucket bucketSomeone = rateLimitingService.resolveAnyResultBucket("someone");
     assertTrue(bucketSomeone.tryConsume(1));
     assertFalse(bucketSomeone.tryConsume(1));
     Thread.sleep(TimeUnit.MILLISECONDS.convert(interval));

--- a/src/test/resources/application.yml
+++ b/src/test/resources/application.yml
@@ -17,3 +17,6 @@ app:
       read:
         any:
           pollingIntervalSeconds: 0
+        detailedObfuscated:
+          amount: 999
+          intervalMinutes: 0

--- a/src/test/resources/application.yml
+++ b/src/test/resources/application.yml
@@ -16,7 +16,7 @@ app:
         intervalMinutes: 1
       read:
         any:
-          pollingIntervalSeconds: 0
+          pollingIntervalSeconds: 1
         detailedObfuscated:
-          amount: 999
-          intervalMinutes: 0
+          amount: 1
+          intervalSeconds: 3


### PR DESCRIPTION
- add a second bucket to enforce a quota on the detailed obfuscated results endpoint
- currently, returning a token back to the bucket when the actually received result was only a summary (due to whatever reason...result no longer available, too few sites responded, too few results received) is done in the afterCompletion method of the interceptor. This does however not allow modifying the headers any more. So a custom header is remaining in this case and the remaining requests variable might be 1 too low