### PR TITLE
#79 - CORS failing

### DIFF
--- a/src/main/java/de/numcodex/feasibility_gui_backend/config/WebSecurityConfig.java
+++ b/src/main/java/de/numcodex/feasibility_gui_backend/config/WebSecurityConfig.java
@@ -113,6 +113,7 @@ public class WebSecurityConfig {
         .and()
         .csrf().disable();
 
+    http.cors();
     return http.build();
   }
 }


### PR DESCRIPTION
- add http.cors() call to WebSecurityConfig to bypass auth checks for OPTIONS requests (according to https://www.baeldung.com/spring-security-cors-preflight#solution )