### PR TITLE
#82 - Security for template and terminology endpoint missing

### DIFF
--- a/src/main/java/de/numcodex/feasibility_gui_backend/config/RateLimitingConfig.java
+++ b/src/main/java/de/numcodex/feasibility_gui_backend/config/RateLimitingConfig.java
@@ -3,7 +3,7 @@ package de.numcodex.feasibility_gui_backend.config;
 import static de.numcodex.feasibility_gui_backend.config.WebSecurityConfig.PATH_API_V2;
 import static de.numcodex.feasibility_gui_backend.config.WebSecurityConfig.PATH_DETAILED_OBFUSCATED_RESULT;
 import static de.numcodex.feasibility_gui_backend.config.WebSecurityConfig.PATH_QUERY;
-import static de.numcodex.feasibility_gui_backend.config.WebSecurityConfig.PATH_QUERY_ID_MATCHER;
+import static de.numcodex.feasibility_gui_backend.config.WebSecurityConfig.PATH_ID_MATCHER;
 import static de.numcodex.feasibility_gui_backend.config.WebSecurityConfig.PATH_SUMMARY_RESULT;
 
 import de.numcodex.feasibility_gui_backend.query.ratelimiting.RateLimitingInterceptor;
@@ -23,7 +23,7 @@ public class RateLimitingConfig implements WebMvcConfigurer {
   @Override
   public void addInterceptors(InterceptorRegistry registry) {
     registry.addInterceptor(interceptor)
-        .addPathPatterns(PATH_API_V2 + PATH_QUERY + PATH_QUERY_ID_MATCHER + PATH_SUMMARY_RESULT)
-        .addPathPatterns(PATH_API_V2 + PATH_QUERY + PATH_QUERY_ID_MATCHER + PATH_DETAILED_OBFUSCATED_RESULT);
+        .addPathPatterns(PATH_API_V2 + PATH_QUERY + PATH_ID_MATCHER + PATH_SUMMARY_RESULT)
+        .addPathPatterns(PATH_API_V2 + PATH_QUERY + PATH_ID_MATCHER + PATH_DETAILED_OBFUSCATED_RESULT);
   }
 }

--- a/src/main/java/de/numcodex/feasibility_gui_backend/config/WebSecurityConfig.java
+++ b/src/main/java/de/numcodex/feasibility_gui_backend/config/WebSecurityConfig.java
@@ -22,7 +22,7 @@ import org.springframework.security.web.SecurityFilterChain;
 
 @Configuration
 @EnableWebSecurity
-@EnableMethodSecurity
+@EnableMethodSecurity(securedEnabled = true, prePostEnabled = false)
 public class WebSecurityConfig {
 
   public static final String KEY_REALM_ACCESS = "realm_access";
@@ -112,8 +112,7 @@ public class WebSecurityConfig {
         .requestMatchers(PATH_API_V2 + "/**").hasAnyAuthority(keycloakAdminRole, keycloakAllowedRole)
         .requestMatchers(PATH_API_V1 + "/**").hasAuthority(keycloakAllowedRole)
         .requestMatchers(PATH_ACTUATOR_HEALTH).anonymous()
-        .anyRequest()
-        .denyAll()
+        .anyRequest().authenticated()
         .and()
         .csrf().disable();
 

--- a/src/main/java/de/numcodex/feasibility_gui_backend/config/WebSecurityConfig.java
+++ b/src/main/java/de/numcodex/feasibility_gui_backend/config/WebSecurityConfig.java
@@ -30,25 +30,19 @@ public class WebSecurityConfig {
   public static final String KEY_RESOURCE_ACCESS = "resource_access";
   public static final String KEY_SPRING_ADDONS_CONFIDENTIAL = "spring-addons-confidential";
   public static final String KEY_SPRING_ADDONS_PUBLIC = "spring-addons-public";
+  public static final String PATH_ACTUATOR_HEALTH = "/actuator/health";
   public static final String PATH_API_V1 = "/api/v1";
   public static final String PATH_API_V2 = "/api/v2";
   public static final String PATH_QUERY = "/query";
   public static final String PATH_ID_MATCHER = "/{id:\\d+}";
   public static final String PATH_USER_ID_MATCHER = "/by-user/{id:[\\w-]+}";
-  public static final String PATH_QUERY_ID_MATCHER = "/{queryId:\\d+}";
   public static final String PATH_SAVED = "/saved";
   public static final String PATH_CONTENT = "/content";
   public static final String PATH_SUMMARY_RESULT = "/summary-result";
   public static final String PATH_DETAILED_OBFUSCATED_RESULT = "/detailed-obfuscated-result";
   public static final String PATH_DETAILED_RESULT = "/detailed-result";
   public static final String PATH_TERMINOLOGY = "/terminology";
-  public static final String PATH_ROOT_ENTRIES = "/root-entries";
-  public static final String PATH_ENTRIES = "/entries";
-  public static final String PATH_NODE_ID_MATCHER = "/{nodeId:\\d+}";
-  public static final String PATH_SELECTABLE_ENTRIES = "/selectable-entries";
-  public static final String PATH_UI_PROFILE = "/ui_profile";
   public static final String PATH_TEMPLATE = "/template";
-  public static final String PATH_VALIDATE = "/validate";
   @Value("${app.keycloakAllowedRole}")
   private String keycloakAllowedRole;
 
@@ -108,24 +102,18 @@ public class WebSecurityConfig {
     }
 
     http.authorizeHttpRequests()
-        .requestMatchers(PATH_API_V1 + "/**").hasAuthority(keycloakAllowedRole)
+        .requestMatchers(PATH_API_V2 + PATH_TERMINOLOGY + "/**").hasAuthority(keycloakAllowedRole)
         .requestMatchers(PATH_API_V2 + PATH_QUERY).hasAuthority(keycloakAllowedRole)
         .requestMatchers(PATH_API_V2 + PATH_QUERY + PATH_USER_ID_MATCHER).hasAuthority(keycloakAdminRole)
-        .requestMatchers(PATH_API_V2 + PATH_QUERY + PATH_ID_MATCHER).hasAnyAuthority(keycloakAdminRole, keycloakAllowedRole)
         .requestMatchers(PATH_API_V2 + PATH_QUERY + PATH_ID_MATCHER + PATH_SAVED).hasAuthority(keycloakAllowedRole)
-        .requestMatchers(PATH_API_V2 + PATH_QUERY + PATH_ID_MATCHER + PATH_SUMMARY_RESULT).hasAnyAuthority(keycloakAdminRole, keycloakAllowedRole)
-        .requestMatchers(PATH_API_V2 + PATH_QUERY + PATH_ID_MATCHER + PATH_DETAILED_OBFUSCATED_RESULT).hasAnyAuthority(keycloakAdminRole, keycloakAllowedRole)
         .requestMatchers(PATH_API_V2 + PATH_QUERY + PATH_ID_MATCHER + PATH_DETAILED_RESULT).hasAuthority(keycloakAdminRole)
-        .requestMatchers(PATH_API_V2 + PATH_QUERY + PATH_ID_MATCHER + PATH_CONTENT).hasAnyAuthority(keycloakAdminRole, keycloakAllowedRole)
-        .requestMatchers(PATH_API_V2 + PATH_TERMINOLOGY + PATH_ROOT_ENTRIES).hasAuthority(keycloakAllowedRole)
-        .requestMatchers(PATH_API_V2 + PATH_TERMINOLOGY + PATH_ENTRIES + PATH_NODE_ID_MATCHER).hasAuthority(keycloakAllowedRole)
-        .requestMatchers(PATH_API_V2 + PATH_TERMINOLOGY + PATH_SELECTABLE_ENTRIES).hasAuthority(keycloakAllowedRole)
-        .requestMatchers(PATH_API_V2 + PATH_TERMINOLOGY + PATH_UI_PROFILE).hasAuthority(keycloakAllowedRole)
         .requestMatchers(PATH_API_V2 + PATH_QUERY + PATH_TEMPLATE).hasAuthority(keycloakAllowedRole)
-        .requestMatchers(PATH_API_V2 + PATH_QUERY + PATH_TEMPLATE + PATH_QUERY_ID_MATCHER).hasAuthority(keycloakAllowedRole)
-        .requestMatchers(PATH_API_V2 + PATH_QUERY + PATH_TEMPLATE + PATH_VALIDATE).hasAuthority(keycloakAllowedRole)
+        .requestMatchers(PATH_API_V2 + PATH_QUERY + PATH_TEMPLATE + "/*").hasAuthority(keycloakAllowedRole)
+        .requestMatchers(PATH_API_V2 + "/**").hasAnyAuthority(keycloakAdminRole, keycloakAllowedRole)
+        .requestMatchers(PATH_API_V1 + "/**").hasAuthority(keycloakAllowedRole)
+        .requestMatchers(PATH_ACTUATOR_HEALTH).anonymous()
         .anyRequest()
-        .permitAll()
+        .denyAll()
         .and()
         .csrf().disable();
 

--- a/src/main/java/de/numcodex/feasibility_gui_backend/config/WebSecurityConfig.java
+++ b/src/main/java/de/numcodex/feasibility_gui_backend/config/WebSecurityConfig.java
@@ -40,6 +40,12 @@ public class WebSecurityConfig {
   public static final String PATH_SUMMARY_RESULT = "/summary-result";
   public static final String PATH_DETAILED_OBFUSCATED_RESULT = "/detailed-obfuscated-result";
   public static final String PATH_DETAILED_RESULT = "/detailed-result";
+  public static final String PATH_TERMINOLOGY = "/terminology";
+  public static final String PATH_ROOT_ENTRIES = "/root-entries";
+  public static final String PATH_ENTRIES = "/entries";
+  public static final String PATH_NODE_ID_MATCHER = "/{nodeId:\\d+}";
+  public static final String PATH_SELECTABLE_ENTRIES = "/selectable-entries";
+  public static final String PATH_UI_PROFILE = "/ui_profile";
   @Value("${app.keycloakAllowedRole}")
   private String keycloakAllowedRole;
 
@@ -108,6 +114,10 @@ public class WebSecurityConfig {
         .requestMatchers(PATH_API_V2 + PATH_QUERY + PATH_QUERY_ID_MATCHER + PATH_DETAILED_OBFUSCATED_RESULT).hasAnyAuthority(keycloakAdminRole, keycloakAllowedRole)
         .requestMatchers(PATH_API_V2 + PATH_QUERY + PATH_QUERY_ID_MATCHER + PATH_DETAILED_RESULT).hasAuthority(keycloakAdminRole)
         .requestMatchers(PATH_API_V2 + PATH_QUERY + PATH_QUERY_ID_MATCHER + PATH_CONTENT).hasAnyAuthority(keycloakAdminRole, keycloakAllowedRole)
+        .requestMatchers(PATH_API_V2 + PATH_TERMINOLOGY + PATH_ROOT_ENTRIES).hasAuthority(keycloakAllowedRole)
+        .requestMatchers(PATH_API_V2 + PATH_TERMINOLOGY + PATH_ENTRIES + PATH_NODE_ID_MATCHER).hasAuthority(keycloakAllowedRole)
+        .requestMatchers(PATH_API_V2 + PATH_TERMINOLOGY + PATH_SELECTABLE_ENTRIES).hasAuthority(keycloakAllowedRole)
+        .requestMatchers(PATH_API_V2 + PATH_TERMINOLOGY + PATH_UI_PROFILE).hasAuthority(keycloakAllowedRole)
         .anyRequest()
         .permitAll()
         .and()

--- a/src/main/java/de/numcodex/feasibility_gui_backend/config/WebSecurityConfig.java
+++ b/src/main/java/de/numcodex/feasibility_gui_backend/config/WebSecurityConfig.java
@@ -33,8 +33,9 @@ public class WebSecurityConfig {
   public static final String PATH_API_V1 = "/api/v1";
   public static final String PATH_API_V2 = "/api/v2";
   public static final String PATH_QUERY = "/query";
-  public static final String PATH_QUERY_ID_MATCHER = "/{id:\\d+}";
+  public static final String PATH_ID_MATCHER = "/{id:\\d+}";
   public static final String PATH_USER_ID_MATCHER = "/by-user/{id:[\\w-]+}";
+  public static final String PATH_QUERY_ID_MATCHER = "/{queryId:\\d+}";
   public static final String PATH_SAVED = "/saved";
   public static final String PATH_CONTENT = "/content";
   public static final String PATH_SUMMARY_RESULT = "/summary-result";
@@ -46,6 +47,8 @@ public class WebSecurityConfig {
   public static final String PATH_NODE_ID_MATCHER = "/{nodeId:\\d+}";
   public static final String PATH_SELECTABLE_ENTRIES = "/selectable-entries";
   public static final String PATH_UI_PROFILE = "/ui_profile";
+  public static final String PATH_TEMPLATE = "/template";
+  public static final String PATH_VALIDATE = "/validate";
   @Value("${app.keycloakAllowedRole}")
   private String keycloakAllowedRole;
 
@@ -108,16 +111,19 @@ public class WebSecurityConfig {
         .requestMatchers(PATH_API_V1 + "/**").hasAuthority(keycloakAllowedRole)
         .requestMatchers(PATH_API_V2 + PATH_QUERY).hasAuthority(keycloakAllowedRole)
         .requestMatchers(PATH_API_V2 + PATH_QUERY + PATH_USER_ID_MATCHER).hasAuthority(keycloakAdminRole)
-        .requestMatchers(PATH_API_V2 + PATH_QUERY + PATH_QUERY_ID_MATCHER).hasAnyAuthority(keycloakAdminRole, keycloakAllowedRole)
-        .requestMatchers(PATH_API_V2 + PATH_QUERY + PATH_QUERY_ID_MATCHER + PATH_SAVED).hasAuthority(keycloakAllowedRole)
-        .requestMatchers(PATH_API_V2 + PATH_QUERY + PATH_QUERY_ID_MATCHER + PATH_SUMMARY_RESULT).hasAnyAuthority(keycloakAdminRole, keycloakAllowedRole)
-        .requestMatchers(PATH_API_V2 + PATH_QUERY + PATH_QUERY_ID_MATCHER + PATH_DETAILED_OBFUSCATED_RESULT).hasAnyAuthority(keycloakAdminRole, keycloakAllowedRole)
-        .requestMatchers(PATH_API_V2 + PATH_QUERY + PATH_QUERY_ID_MATCHER + PATH_DETAILED_RESULT).hasAuthority(keycloakAdminRole)
-        .requestMatchers(PATH_API_V2 + PATH_QUERY + PATH_QUERY_ID_MATCHER + PATH_CONTENT).hasAnyAuthority(keycloakAdminRole, keycloakAllowedRole)
+        .requestMatchers(PATH_API_V2 + PATH_QUERY + PATH_ID_MATCHER).hasAnyAuthority(keycloakAdminRole, keycloakAllowedRole)
+        .requestMatchers(PATH_API_V2 + PATH_QUERY + PATH_ID_MATCHER + PATH_SAVED).hasAuthority(keycloakAllowedRole)
+        .requestMatchers(PATH_API_V2 + PATH_QUERY + PATH_ID_MATCHER + PATH_SUMMARY_RESULT).hasAnyAuthority(keycloakAdminRole, keycloakAllowedRole)
+        .requestMatchers(PATH_API_V2 + PATH_QUERY + PATH_ID_MATCHER + PATH_DETAILED_OBFUSCATED_RESULT).hasAnyAuthority(keycloakAdminRole, keycloakAllowedRole)
+        .requestMatchers(PATH_API_V2 + PATH_QUERY + PATH_ID_MATCHER + PATH_DETAILED_RESULT).hasAuthority(keycloakAdminRole)
+        .requestMatchers(PATH_API_V2 + PATH_QUERY + PATH_ID_MATCHER + PATH_CONTENT).hasAnyAuthority(keycloakAdminRole, keycloakAllowedRole)
         .requestMatchers(PATH_API_V2 + PATH_TERMINOLOGY + PATH_ROOT_ENTRIES).hasAuthority(keycloakAllowedRole)
         .requestMatchers(PATH_API_V2 + PATH_TERMINOLOGY + PATH_ENTRIES + PATH_NODE_ID_MATCHER).hasAuthority(keycloakAllowedRole)
         .requestMatchers(PATH_API_V2 + PATH_TERMINOLOGY + PATH_SELECTABLE_ENTRIES).hasAuthority(keycloakAllowedRole)
         .requestMatchers(PATH_API_V2 + PATH_TERMINOLOGY + PATH_UI_PROFILE).hasAuthority(keycloakAllowedRole)
+        .requestMatchers(PATH_API_V2 + PATH_QUERY + PATH_TEMPLATE).hasAuthority(keycloakAllowedRole)
+        .requestMatchers(PATH_API_V2 + PATH_QUERY + PATH_TEMPLATE + PATH_QUERY_ID_MATCHER).hasAuthority(keycloakAllowedRole)
+        .requestMatchers(PATH_API_V2 + PATH_QUERY + PATH_TEMPLATE + PATH_VALIDATE).hasAuthority(keycloakAllowedRole)
         .anyRequest()
         .permitAll()
         .and()

--- a/src/main/java/de/numcodex/feasibility_gui_backend/query/v2/QueryTemplateHandlerRestController.java
+++ b/src/main/java/de/numcodex/feasibility_gui_backend/query/v2/QueryTemplateHandlerRestController.java
@@ -18,7 +18,6 @@ import org.springframework.dao.DataIntegrityViolationException;
 import org.springframework.http.HttpHeaders;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
-import org.springframework.security.access.prepost.PreAuthorize;
 import org.springframework.web.bind.annotation.CrossOrigin;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
@@ -50,7 +49,6 @@ public class QueryTemplateHandlerRestController {
   }
 
   @PostMapping(path = "")
-  @PreAuthorize("hasRole(@environment.getProperty('app.keycloakAllowedRole'))")
   public ResponseEntity<Object> storeQueryTemplate(@Valid @RequestBody QueryTemplate queryTemplate,
       @Context HttpServletRequest httpServletRequest, Principal principal) {
 
@@ -78,7 +76,6 @@ public class QueryTemplateHandlerRestController {
   }
 
   @GetMapping(path = "/{queryId}")
-  @PreAuthorize("hasRole(@environment.getProperty('app.keycloakAllowedRole'))")
   public ResponseEntity<Object> getQueryTemplate(@PathVariable(value = "queryId") Long queryId,
       Principal principal) {
 
@@ -97,7 +94,6 @@ public class QueryTemplateHandlerRestController {
   }
 
   @GetMapping(path = "")
-  @PreAuthorize("hasRole(@environment.getProperty('app.keycloakAllowedRole'))")
   public ResponseEntity<Object> getQueryTemplates(Principal principal) {
 
     var queries = queryHandlerService.getQueryTemplatesForAuthor(principal.getName());
@@ -115,7 +111,6 @@ public class QueryTemplateHandlerRestController {
   }
 
   @GetMapping(path = "/validate")
-  @PreAuthorize("hasRole(@environment.getProperty('app.keycloakAllowedRole'))")
   public ResponseEntity<Object> validateTemplates(Principal principal) {
 
     var queries = queryHandlerService.getQueryTemplatesForAuthor(principal.getName());

--- a/src/main/java/de/numcodex/feasibility_gui_backend/terminology/TerminologyRestController.java
+++ b/src/main/java/de/numcodex/feasibility_gui_backend/terminology/TerminologyRestController.java
@@ -5,7 +5,6 @@ import de.numcodex.feasibility_gui_backend.terminology.api.CategoryEntry;
 import de.numcodex.feasibility_gui_backend.terminology.api.TerminologyEntry;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.http.MediaType;
-import org.springframework.security.access.prepost.PreAuthorize;
 import org.springframework.web.bind.annotation.*;
 
 import java.util.List;
@@ -30,26 +29,22 @@ public class TerminologyRestController {
     }
 
     @GetMapping("entries/{nodeId}")
-    @PreAuthorize("hasRole(@environment.getProperty('app.keycloakAllowedRole'))")
     public TerminologyEntry getEntry(@PathVariable UUID nodeId) {
         return terminologyService.getEntry(nodeId);
     }
 
     @GetMapping("root-entries")
-    @PreAuthorize("hasRole(@environment.getProperty('app.keycloakAllowedRole'))")
     public List<CategoryEntry> getCategories() {
         return terminologyService.getCategories();
     }
 
     @GetMapping("selectable-entries")
-    @PreAuthorize("hasRole(@environment.getProperty('app.keycloakAllowedRole'))")
     public List<TerminologyEntry> getSelectableEntries(@RequestParam("query") String query,
                                                        @RequestParam(value = "categoryId", required = false) UUID categoryId) {
         return terminologyService.getSelectableEntries(query, categoryId);
     }
 
     @GetMapping(value = "ui_profile", produces = MediaType.APPLICATION_JSON_VALUE)
-    @PreAuthorize("hasRole(@environment.getProperty('app.keycloakAllowedRole'))")
     public String getUiProfile(@RequestParam("system") String system, @RequestParam("code") String code, @RequestParam(value = "version", required = false) String version) {
         return terminologyService.getUiProfile(system, code, version);
     }


### PR DESCRIPTION
- move authorization check for terminology and template endpoints to the central WebSecurityConfig instead of using PreAuthorize annotations
- close #82 