### PR TITLE
#117 - Extend query result to allow for empty result parts

### DIFF
--- a/src/main/java/de/numcodex/feasibility_gui_backend/query/api/QueryResult.java
+++ b/src/main/java/de/numcodex/feasibility_gui_backend/query/api/QueryResult.java
@@ -1,5 +1,6 @@
 package de.numcodex.feasibility_gui_backend.query.api;
 
+import com.fasterxml.jackson.annotation.JsonInclude;
 import lombok.Builder;
 import lombok.Data;
 
@@ -7,8 +8,11 @@ import java.util.List;
 
 @Data
 @Builder
+@JsonInclude(JsonInclude.Include.NON_NULL)
 public class QueryResult {
-    private long totalNumberOfPatients;
+    private Long totalNumberOfPatients;
     private Long queryId;
     private List<QueryResultLine> resultLines;
+    private ResultAbsentReason absentReasonTotal;
+    private ResultAbsentReason absentReasonResultLines;
 }

--- a/src/main/java/de/numcodex/feasibility_gui_backend/query/api/ResultAbsentReason.java
+++ b/src/main/java/de/numcodex/feasibility_gui_backend/query/api/ResultAbsentReason.java
@@ -1,0 +1,6 @@
+package de.numcodex.feasibility_gui_backend.query.api;
+
+public enum ResultAbsentReason {
+    RESULT_TOO_SMALL,
+    NOT_ENOUGH_SITES;
+}

--- a/src/main/java/de/numcodex/feasibility_gui_backend/query/v2/QueryHandlerRestController.java
+++ b/src/main/java/de/numcodex/feasibility_gui_backend/query/v2/QueryHandlerRestController.java
@@ -9,6 +9,7 @@ import de.numcodex.feasibility_gui_backend.query.QueryNotFoundException;
 import de.numcodex.feasibility_gui_backend.query.api.QueryListEntry;
 import de.numcodex.feasibility_gui_backend.query.api.QueryResult;
 import de.numcodex.feasibility_gui_backend.query.api.QueryResultRateLimit;
+import de.numcodex.feasibility_gui_backend.query.api.ResultAbsentReason;
 import de.numcodex.feasibility_gui_backend.query.api.SavedQuery;
 import de.numcodex.feasibility_gui_backend.query.api.StructuredQuery;
 import de.numcodex.feasibility_gui_backend.query.persistence.UserBlacklist;
@@ -212,13 +213,15 @@ public class QueryHandlerRestController {
         ResultDetail.DETAILED_OBFUSCATED);
 
     if (queryResult.getTotalNumberOfPatients() < privacyThresholdResults) {
-      return new ResponseEntity<>(HttpStatus.NO_CONTENT);
+      queryResult.setAbsentReasonTotal(ResultAbsentReason.RESULT_TOO_SMALL);
+      queryResult.setTotalNumberOfPatients(null);
     }
     HttpHeaders headers = new HttpHeaders();
     if (queryResult.getResultLines().size() < privacyThresholdSites) {
-      queryResult.setResultLines(List.of());
+      queryResult.setAbsentReasonResultLines(ResultAbsentReason.NOT_ENOUGH_SITES);
+      queryResult.setResultLines(null);
     }
-    if (queryResult.getResultLines().isEmpty()) {
+    if (queryResult.getResultLines() == null || queryResult.getResultLines().isEmpty()) {
       headers.add(HEADER_X_DETAILED_OBFUSCATED_RESULT_WAS_EMPTY, "true");
     }
     return new ResponseEntity<>(queryResult, headers, HttpStatus.OK);
@@ -246,7 +249,8 @@ public class QueryHandlerRestController {
     var queryResult = queryHandlerService.getQueryResult(queryId, ResultDetail.SUMMARY);
 
     if (queryResult.getTotalNumberOfPatients() < privacyThresholdResults) {
-      return new ResponseEntity<>(HttpStatus.NO_CONTENT);
+      queryResult.setAbsentReasonTotal(ResultAbsentReason.RESULT_TOO_SMALL);
+      queryResult.setTotalNumberOfPatients(null);
     }
     return new ResponseEntity<>(queryResult, HttpStatus.OK);
   }


### PR DESCRIPTION
Changed the return value for redacted queries for privacy reasons.

See #117 for a description. I'm not quite sure if the enum I added is as desired though.