### PR TITLE
#126 - Fix code scanning alert - Spring Security logout not clearing security context

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -26,8 +26,8 @@
     <java.version>17</java.version>
     <mockwebserver.version>4.10.0</mockwebserver.version>
     <okhttp3.version>4.10.0</okhttp3.version>
-    <spring-security.version>6.0.2</spring-security.version>
-    <spring-security-test.version>6.0.2</spring-security-test.version>
+    <spring-security.version>6.1.0</spring-security.version>
+    <spring-security-test.version>6.1.0</spring-security-test.version>
   </properties>
 
   <dependencies>


### PR DESCRIPTION
update spring security to 6.1.0 to fix https://avd.aquasec.com/nvd/cve-2023-20862