### PR TITLE
#145 - Run Java in Docker Container as Non-Root

### DIFF
--- a/.github/scripts/check-if-running-as-feasibility-user.sh
+++ b/.github/scripts/check-if-running-as-feasibility-user.sh
@@ -1,0 +1,10 @@
+#!/bin/bash -e
+
+if docker exec -u0 feasibility-gui-backend pgrep -u feasibility java > /dev/null
+then
+    echo "Java process is running as feasibility"
+    exit 0
+else
+    echo "Java process is not running as feasibility"
+    exit 1
+fi

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -139,6 +139,13 @@ jobs:
       - name: Wait for Feasibility Backend
         run: .github/scripts/wait-for-url.sh  http://localhost:8091/actuator/health
 
+      - name: Check if Feasibility Backend is correctly running with the feasibility user
+        run: .github/scripts/check-if-running-as-feasibility-user.sh
+
+      - name: Dump docker logs on failure
+        if: failure()
+        uses: jwalton/gh-docker-logs@v2
+
   release:
     if: ${{ startsWith(github.ref, 'refs/tags/v') }}
     needs:

--- a/Dockerfile
+++ b/Dockerfile
@@ -6,6 +6,12 @@ WORKDIR /opt/codex-feasibility-backend
 COPY ./target/*.jar ./feasibility-gui-backend.jar
 COPY ontology ontology
 
+RUN addgroup --system feasibility && adduser --system feasibility --ingroup feasibility
+RUN mkdir logging
+RUN chown -R feasibility:feasibility /opt/codex-feasibility-backend
+
+USER feasibility:feasibility
+
 ARG VERSION=2.1.0
 ENV APP_VERSION=${VERSION}
 ENV FEASIBILITY_DATABASE_HOST="feasibility-network"


### PR DESCRIPTION
- create a user and group "feasibility" in the Dockerfile that runs the application instead of root user
- add a script that checks if java is really running as the user "feasibility" during github actions