### PR TITLE
#149 - Insecure temporary directory creation

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -133,13 +133,27 @@
     <dependency>
       <groupId>ca.uhn.hapi.fhir</groupId>
       <artifactId>hapi-fhir-client</artifactId>
-      <version>6.4.2</version>
+      <version>6.6.2</version>
+      <exclusions>
+        <exclusion>
+          <groupId>com.google</groupId>
+          <artifactId>guava</artifactId>
+        </exclusion>
+      </exclusions>
     </dependency>
+
+    <!-- Guava up to 31.1 is affected by https://avd.aquasec.com/nvd/2023/cve-2023-2976/ -->
+    <dependency>
+      <groupId>com.google.guava</groupId>
+      <artifactId>guava</artifactId>
+      <version>32.1.1-jre</version>
+    </dependency>
+
 
     <dependency>
       <groupId>ca.uhn.hapi.fhir</groupId>
       <artifactId>hapi-fhir-structures-r4</artifactId>
-      <version>6.4.2</version>
+      <version>6.6.2</version>
     </dependency>
 
     <dependency>


### PR DESCRIPTION
- update hapi libs
- exclude guava dependency from hapi libs and add newer version to fix https://avd.aquasec.com/nvd/2023/cve-2023-2976/