### PR TITLE
#155 - Close the Inputstream

### DIFF
--- a/src/main/java/de/numcodex/feasibility_gui_backend/query/broker/dsf/DSFFhirSecurityContextProvider.java
+++ b/src/main/java/de/numcodex/feasibility_gui_backend/query/broker/dsf/DSFFhirSecurityContextProvider.java
@@ -41,11 +41,12 @@ public class DSFFhirSecurityContextProvider implements FhirSecurityContextProvid
             if (!Files.isReadable(Paths.get(certificateFile))) {
                 throw new IOException("Certificate file '" + certificateFile + "' not readable");
             }
-            FileInputStream inStream = new FileInputStream(certificateFile);
-            CertificateFactory cf = CertificateFactory.getInstance("X.509");
+            try (FileInputStream inStream = new FileInputStream(certificateFile)) {
+                CertificateFactory cf = CertificateFactory.getInstance("X.509");
 
-            for (Certificate cert : cf.generateCertificates(inStream)) {
-                localTrustStore.setCertificateEntry(getCertificateName(cert), cert);
+                for (Certificate cert : cf.generateCertificates(inStream)) {
+                    localTrustStore.setCertificateEntry(getCertificateName(cert), cert);
+                }
             }
 
             return new FhirSecurityContext(localKeyStore, localTrustStore, keyStorePassword);


### PR DESCRIPTION
- Declare FileInputStream in DSFFhirSecurityContextProvider in try-with-resources statement so that it is automatically closed afterwards