### PR TITLE
Hotfix 3.1.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,11 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 
+## [3.1.2] - 2023-07-11
+
+### Security
+- Fix potential input resource leak ([#155](https://github.com/medizininformatik-initiative/feasibility-backend/issues/155))
+
 ## [3.1.1] - 2023-05-24
 
 ### Fixed

--- a/pom.xml
+++ b/pom.xml
@@ -11,7 +11,7 @@
 
   <groupId>de.medizininformatik-initiative</groupId>
   <artifactId>FeasibilityGuiBackend</artifactId>
-  <version>3.1.1</version>
+  <version>3.1.2</version>
 
   <name>FeasibilityGuiBackend</name>
   <description>Backend of the Feasibility GUI</description>

--- a/src/main/java/de/numcodex/feasibility_gui_backend/query/broker/dsf/DSFFhirSecurityContextProvider.java
+++ b/src/main/java/de/numcodex/feasibility_gui_backend/query/broker/dsf/DSFFhirSecurityContextProvider.java
@@ -40,11 +40,12 @@ public class DSFFhirSecurityContextProvider implements FhirSecurityContextProvid
             if (!Files.isReadable(Paths.get(certificateFile))) {
                 throw new IOException("Certificate file '" + certificateFile + "' not readable");
             }
-            FileInputStream inStream = new FileInputStream(certificateFile);
-            CertificateFactory cf = CertificateFactory.getInstance("X.509");
-            Certificate cert = cf.generateCertificate(inStream);
+            try (FileInputStream inStream = new FileInputStream(certificateFile)) {
+                CertificateFactory cf = CertificateFactory.getInstance("X.509");
+                Certificate cert = cf.generateCertificate(inStream);
 
-            localTrustStore.setCertificateEntry("zars", cert);
+                localTrustStore.setCertificateEntry("zars", cert);
+            }
 
             return new FhirSecurityContext(localKeyStore, localTrustStore, keyStorePassword);
         } catch (Exception e) {


### PR DESCRIPTION
- Declare FileInputStream in DSFFhirSecurityContextProvider in try-with-resources statement so that it is automatically closed afterward