### PR TITLE
#179 - Make restriction when site counts as answered configurable

### DIFF
--- a/README.md
+++ b/README.md
@@ -116,7 +116,8 @@ If the number of total results is below threshold, no result will be provided.
 | PRIVACY_QUOTA_READ_DETAILED_OBFUSCATED_AMOUNT                 | Amount of times a user can create a distinct detailed obfuscated result in the interval defined in _PRIVACY_QUOTA_READ_DETAILED_OBFUSCATED_INTERVALSECONDS _. |         | 10      |
 | PRIVACY_QUOTA_READ_DETAILED_OBFUSCATED_INTERVALSECONDS        | (see description above)                                                                                                                                       |         | 3       |
 | PRIVACY_THRESHOLD_RESULTS                                     | If the total number of results is below this number, return an empty result instead.                                                                          |         | 3       |
-| PRIVACY_THRESHOLD_SITES                                       | If the number of responding sites is below this number, only respond with a total amount of patients                                                          |         | 20      |
+| PRIVACY_THRESHOLD_SITES                                       | If the number of responding sites (above PRIVACY_THRESHOLD_SITES_RESULT) is below this number, only respond with a total amount of patients                   |         | 20      |
+| PRIVACY_THRESHOLD_SITES_RESULT                                | Any site that reports a number below this threshold is considered as non-responding (or zero) in regard to PRIVACY_THRESHOLD_SITES                            |         | 20      |
 
 ## Setting up Development
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -63,6 +63,7 @@ services:
       # If the total result for a query is below this number, return an empty result instead.
       PRIVACY_THRESHOLD_RESULTS: ${CODEX_FEASIBILITY_BACKEND_PRIVACY_THRESHOLD_RESULTS}
       PRIVACY_THRESHOLD_SITES: ${CODEX_FEASIBILITY_BACKEND_PRIVACY_THRESHOLD_SITES}
+      PRIVACY_THRESHOLD_SITES_RESULT: ${CODEX_FEASIBILITY_BACKEND_PRIVACY_THRESHOLD_SITES_RESULT}
     volumes:
       - ${CODEX_FEASIBILITY_BACKEND_LOCAL_CONCEPT_TREE_PATH:-./ontology/codex-code-tree.json}:${CODEX_FEASIBILITY_BACKEND_ONTOLOGY_FILES_FOLDER:-/opt/codex-feasibility-backend/ontology}/codex-code-tree.json
       - ${CODEX_FEASIBILITY_BACKEND_LOCAL_TERM_CODE_MAPPING_PATH:-./ontology/codex-term-code-mapping.json}:${CODEX_FEASIBILITY_BACKEND_ONTOLOGY_FILES_FOLDER:-/opt/codex-feasibility-backend/ontology}/codex-term-code-mapping.json

--- a/src/main/java/de/numcodex/feasibility_gui_backend/query/v3/QueryHandlerRestController.java
+++ b/src/main/java/de/numcodex/feasibility_gui_backend/query/v3/QueryHandlerRestController.java
@@ -89,6 +89,9 @@ public class QueryHandlerRestController {
   @Value("${app.privacy.threshold.results}")
   private int privacyThresholdResults;
 
+  @Value("${app.privacy.threshold.sitesResult}")
+  private int privacyThresholdSitesResult;
+
   public QueryHandlerRestController(QueryHandlerService queryHandlerService,
       RateLimitingService rateLimitingService,
       TermCodeValidation termCodeValidation,
@@ -264,13 +267,13 @@ public class QueryHandlerRestController {
           HttpStatus.OK);
     }
     HttpHeaders headers = new HttpHeaders();
-    if (queryResult.resultLines().size() < privacyThresholdSites) {
+    if (queryResult.resultLines().stream().filter(result -> result.numberOfPatients() > privacyThresholdSitesResult).count() < privacyThresholdSites) {
       var issues = FeasibilityIssues.builder()
               .issues(List.of(FeasibilityIssue.PRIVACY_RESTRICTION_RESULT_SITES))
               .build();
       return new ResponseEntity<>(
-          issues,
-          HttpStatus.OK);
+              issues,
+              HttpStatus.OK);
     }
     if (queryResult.resultLines().isEmpty()) {
       headers.add(HEADER_X_DETAILED_OBFUSCATED_RESULT_WAS_EMPTY, "true");

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -89,6 +89,7 @@ app:
     threshold:
       sites: ${PRIVACY_THRESHOLD_SITES:3}
       results: ${PRIVACY_THRESHOLD_RESULTS:20}
+      sitesResult: ${PRIVACY_THRESHOLD_SITES_RESULT:20}
     quota:
       soft:
         create:

--- a/src/test/java/de/numcodex/feasibility_gui_backend/query/v3/QueryTemplateHandlerRestControllerIT.java
+++ b/src/test/java/de/numcodex/feasibility_gui_backend/query/v3/QueryTemplateHandlerRestControllerIT.java
@@ -33,6 +33,7 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.concurrent.ThreadLocalRandom;
 
+import static de.numcodex.feasibility_gui_backend.config.WebSecurityConfig.*;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.doReturn;
 import static org.mockito.Mockito.doThrow;
@@ -76,18 +77,18 @@ public class QueryTemplateHandlerRestControllerIT {
         long queryId = 1;
         doReturn(queryId).when(queryHandlerService).storeQueryTemplate(any(QueryTemplate.class), any(String.class));
 
-        mockMvc.perform(post(URI.create("/api/v3/query/template")).with(csrf())
+        mockMvc.perform(post(URI.create(PATH_API + PATH_QUERY + PATH_TEMPLATE)).with(csrf())
                         .contentType(APPLICATION_JSON)
                         .content(jsonUtil.writeValueAsString(createValidQueryTemplateToStore(queryId))))
                 .andExpect(status().isCreated())
                 .andExpect(header().exists("location"))
-                .andExpect(header().string("location", "/api/v3/query/template/" + queryId));
+                .andExpect(header().string("location", PATH_API + PATH_QUERY + PATH_TEMPLATE + "/" + queryId));
     }
 
     @Test
     @WithMockUser(roles = "FEASIBILITY_TEST_USER")
     public void testStoreQueryTemplate_failsOnInvalidQueryTemplate() throws Exception {
-        mockMvc.perform(post(URI.create("/api/v3/query/template")).with(csrf())
+        mockMvc.perform(post(URI.create(PATH_API + PATH_QUERY + PATH_TEMPLATE)).with(csrf())
                         .contentType(APPLICATION_JSON)
                         .content("{}"))
                 .andExpect(status().isBadRequest());
@@ -98,7 +99,7 @@ public class QueryTemplateHandlerRestControllerIT {
     public void testStoreQueryTemplate_failsOnTemplateExceptionWith500() throws Exception {
         doThrow(QueryTemplateException.class).when(queryHandlerService).storeQueryTemplate(any(QueryTemplate.class), any(String.class));
 
-        mockMvc.perform(post(URI.create("/api/v3/query/template")).with(csrf())
+        mockMvc.perform(post(URI.create(PATH_API + PATH_QUERY + PATH_TEMPLATE)).with(csrf())
                         .contentType(APPLICATION_JSON)
                         .content(jsonUtil.writeValueAsString(createValidQueryTemplateToStore(1L))))
                 .andExpect(status().isInternalServerError());
@@ -109,7 +110,7 @@ public class QueryTemplateHandlerRestControllerIT {
     public void testStoreQueryTemplate_failsOnDuplicateWith409() throws Exception {
         doThrow(DataIntegrityViolationException.class).when(queryHandlerService).storeQueryTemplate(any(QueryTemplate.class), any(String.class));
 
-        mockMvc.perform(post(URI.create("/api/v3/query/template")).with(csrf())
+        mockMvc.perform(post(URI.create(PATH_API + PATH_QUERY + PATH_TEMPLATE)).with(csrf())
                         .contentType(APPLICATION_JSON)
                         .content(jsonUtil.writeValueAsString(createValidQueryTemplateToStore(1L))))
                 .andExpect(status().isConflict());
@@ -124,7 +125,7 @@ public class QueryTemplateHandlerRestControllerIT {
         doReturn(createValidApiQueryTemplateToGet(queryTemplateId)).when(queryHandlerService).convertTemplatePersistenceToApi(any(de.numcodex.feasibility_gui_backend.query.persistence.QueryTemplate.class));
         doReturn(List.of()).when(termCodeValidation).getInvalidTermCodes(any(StructuredQuery.class));
 
-        mockMvc.perform(get(URI.create("/api/v3/query/template/" + queryTemplateId)).with(csrf()))
+        mockMvc.perform(get(URI.create(PATH_API + PATH_QUERY + PATH_TEMPLATE + "/" + queryTemplateId)).with(csrf()))
                 .andExpect(status().isOk())
                 .andExpect(jsonPath("$.id").value(queryTemplateId));
     }
@@ -138,7 +139,7 @@ public class QueryTemplateHandlerRestControllerIT {
         doReturn(createValidApiQueryTemplateToGet(queryTemplateId)).when(queryHandlerService).convertTemplatePersistenceToApi(any(de.numcodex.feasibility_gui_backend.query.persistence.QueryTemplate.class));
         doReturn(List.of()).when(termCodeValidation).getInvalidTermCodes(any(StructuredQuery.class));
 
-        mockMvc.perform(get(URI.create("/api/v3/query/template/" + queryTemplateId)).with(csrf()))
+        mockMvc.perform(get(URI.create(PATH_API + PATH_QUERY + PATH_TEMPLATE + "/" + queryTemplateId)).with(csrf()))
                 .andExpect(status().isNotFound());
     }
 
@@ -151,7 +152,7 @@ public class QueryTemplateHandlerRestControllerIT {
         doThrow(JsonProcessingException.class).when(queryHandlerService).convertTemplatePersistenceToApi(any(de.numcodex.feasibility_gui_backend.query.persistence.QueryTemplate.class));
         doReturn(List.of()).when(termCodeValidation).getInvalidTermCodes(any(StructuredQuery.class));
 
-        mockMvc.perform(get(URI.create("/api/v3/query/template/" + queryTemplateId)).with(csrf()))
+        mockMvc.perform(get(URI.create(PATH_API + PATH_QUERY + PATH_TEMPLATE + "/" + queryTemplateId)).with(csrf()))
                 .andExpect(status().isInternalServerError());
     }
 
@@ -162,7 +163,7 @@ public class QueryTemplateHandlerRestControllerIT {
         doReturn(createValidPersistenceQueryTemplateListToGet(listSize)).when(queryHandlerService).getQueryTemplatesForAuthor(any(String.class));
         doReturn(createValidApiQueryTemplateToGet(ThreadLocalRandom.current().nextInt())).when(queryHandlerService).convertTemplatePersistenceToApi(any(de.numcodex.feasibility_gui_backend.query.persistence.QueryTemplate.class));
 
-        mockMvc.perform(get(URI.create("/api/v3/query/template")).with(csrf()))
+        mockMvc.perform(get(URI.create(PATH_API + PATH_QUERY + PATH_TEMPLATE)).with(csrf()))
                 .andExpect(status().isOk())
                 .andExpect(jsonPath("$.length()").value(listSize))
                 .andExpect(jsonPath("$.[0].id").exists());
@@ -174,7 +175,7 @@ public class QueryTemplateHandlerRestControllerIT {
         doReturn(createValidPersistenceQueryTemplateListToGet(5)).when(queryHandlerService).getQueryTemplatesForAuthor(any(String.class));
         doThrow(JsonProcessingException.class).when(queryHandlerService).convertTemplatePersistenceToApi(any(de.numcodex.feasibility_gui_backend.query.persistence.QueryTemplate.class));
 
-        mockMvc.perform(get(URI.create("/api/v3/query/template")).with(csrf()))
+        mockMvc.perform(get(URI.create(PATH_API + PATH_QUERY + PATH_TEMPLATE)).with(csrf()))
                 .andExpect(status().isOk())
                 .andExpect(jsonPath("$.length()").value(0));
     }
@@ -187,7 +188,7 @@ public class QueryTemplateHandlerRestControllerIT {
         doReturn(createValidApiQueryTemplateToGet(ThreadLocalRandom.current().nextInt())).when(queryHandlerService).convertTemplatePersistenceToApi(any(de.numcodex.feasibility_gui_backend.query.persistence.QueryTemplate.class));
         doReturn(List.of()).when(termCodeValidation).getInvalidTermCodes(any(StructuredQuery.class));
 
-        mockMvc.perform(get(URI.create("/api/v3/query/template/validate")).with(csrf()))
+        mockMvc.perform(get(URI.create(PATH_API + PATH_QUERY + PATH_TEMPLATE + "/validate")).with(csrf()))
                 .andExpect(status().isOk())
                 .andExpect(jsonPath("$.length()").value(listSize))
                 .andExpect(jsonPath("$.[*].id").exists())
@@ -202,7 +203,7 @@ public class QueryTemplateHandlerRestControllerIT {
         doReturn(createValidApiQueryTemplateToGet(ThreadLocalRandom.current().nextInt())).when(queryHandlerService).convertTemplatePersistenceToApi(any(de.numcodex.feasibility_gui_backend.query.persistence.QueryTemplate.class));
         doReturn(List.of(createTermCode())).when(termCodeValidation).getInvalidTermCodes(any(StructuredQuery.class));
 
-        mockMvc.perform(get(URI.create("/api/v3/query/template/validate")).with(csrf()))
+        mockMvc.perform(get(URI.create(PATH_API + PATH_QUERY + PATH_TEMPLATE + "/validate")).with(csrf()))
                 .andExpect(status().isOk())
                 .andExpect(jsonPath("$.length()").value(listSize));
     }
@@ -215,7 +216,7 @@ public class QueryTemplateHandlerRestControllerIT {
         doThrow(JsonProcessingException.class).when(queryHandlerService).convertTemplatePersistenceToApi(any(de.numcodex.feasibility_gui_backend.query.persistence.QueryTemplate.class));
         doReturn(List.of(createTermCode())).when(termCodeValidation).getInvalidTermCodes(any(StructuredQuery.class));
 
-        mockMvc.perform(get(URI.create("/api/v3/query/template/validate")).with(csrf()))
+        mockMvc.perform(get(URI.create(PATH_API + PATH_QUERY + PATH_TEMPLATE + "/validate")).with(csrf()))
                 .andExpect(status().isOk())
                 .andExpect(jsonPath("$.length()").value(0));
     }

--- a/src/test/java/de/numcodex/feasibility_gui_backend/terminology/v3/TerminologyRestControllerIT.java
+++ b/src/test/java/de/numcodex/feasibility_gui_backend/terminology/v3/TerminologyRestControllerIT.java
@@ -34,6 +34,8 @@ import java.net.URI;
 import java.util.List;
 import java.util.UUID;
 
+import static de.numcodex.feasibility_gui_backend.config.WebSecurityConfig.PATH_API;
+import static de.numcodex.feasibility_gui_backend.config.WebSecurityConfig.PATH_TERMINOLOGY;
 import static org.mockito.ArgumentMatchers.*;
 import static org.mockito.Mockito.doReturn;
 import static org.mockito.Mockito.doThrow;
@@ -73,7 +75,7 @@ public class TerminologyRestControllerIT {
         var terminologyEntry = createTerminologyEntry(id);
         doReturn(terminologyEntry).when(terminologyService).getEntry(any(UUID.class));
 
-        mockMvc.perform(get(URI.create("/api/v3/terminology/entries/" + id)).with(csrf()))
+        mockMvc.perform(get(URI.create(PATH_API + PATH_TERMINOLOGY + "/entries/" + id)).with(csrf()))
                 .andExpect(status().isOk())
                 .andExpect(jsonPath("$.id").value(id.toString()))
                 .andExpect(jsonPath("$.context.code").value(terminologyEntry.getContext().code()))
@@ -89,7 +91,7 @@ public class TerminologyRestControllerIT {
     public void testGetEntry_failsWith404OnNotFound() throws Exception {
         Mockito.doThrow(NodeNotFoundException.class).when(terminologyService).getEntry(any(UUID.class));
 
-        mockMvc.perform(get(URI.create("/api/v3/terminology/entries/" + UUID.randomUUID())).with(csrf()))
+        mockMvc.perform(get(URI.create(PATH_API + PATH_TERMINOLOGY + "/entries/" + UUID.randomUUID())).with(csrf()))
                 .andExpect(status().isNotFound());
     }
 
@@ -99,7 +101,7 @@ public class TerminologyRestControllerIT {
         List<CategoryEntry> categoryEntries = createCategoryEntries();
         doReturn(categoryEntries).when(terminologyService).getCategories();
 
-        mockMvc.perform(get(URI.create("/api/v3/terminology/categories")).with(csrf()))
+        mockMvc.perform(get(URI.create(PATH_API + PATH_TERMINOLOGY + "/categories")).with(csrf()))
                 .andDo(print())
                 .andExpect(status().isOk())
                 .andExpect(jsonPath("$.length()").value(categoryEntries.size()))
@@ -119,13 +121,13 @@ public class TerminologyRestControllerIT {
         doReturn(terminologyEntries).when(terminologyService).getSelectableEntries(any(String.class), isNull());
 
         if (includeCategory) {
-            requestBuilder = get(URI.create("/api/v3/terminology/entries"))
+            requestBuilder = get(URI.create(PATH_API + PATH_TERMINOLOGY + "/entries"))
                     .param("query", "GESCH")
                     .param("categoryId", UUID.randomUUID().toString())
                     .with(csrf());
 
         } else {
-            requestBuilder = get(URI.create("/api/v3/terminology/entries"))
+            requestBuilder = get(URI.create(PATH_API + PATH_TERMINOLOGY + "/entries"))
                     .param("query", "GESCH")
                     .with(csrf());
 
@@ -147,7 +149,7 @@ public class TerminologyRestControllerIT {
     public void testGetSelectableEntries_succeedsWith200ButEmptyOnNoMatch() throws Exception {
         doReturn(List.of()).when(terminologyService).getSelectableEntries(any(String.class), any(UUID.class));
 
-        mockMvc.perform(get(URI.create("/api/v3/terminology/entries"))
+        mockMvc.perform(get(URI.create(PATH_API + PATH_TERMINOLOGY + "/entries"))
                         .param("query", "GESCH")
                         .with(csrf()))
                 .andExpect(status().isOk())
@@ -159,7 +161,7 @@ public class TerminologyRestControllerIT {
     public void testGetSelectableEntries_failsWith400OnMissingQueryParameter() throws Exception {
         doReturn(List.of()).when(terminologyService).getSelectableEntries(any(String.class), any(UUID.class));
 
-        mockMvc.perform(get(URI.create("/api/v3/terminology/entries"))
+        mockMvc.perform(get(URI.create(PATH_API + PATH_TERMINOLOGY + "/entries"))
                         .with(csrf()))
                 .andExpect(status().isBadRequest());
     }
@@ -170,7 +172,7 @@ public class TerminologyRestControllerIT {
         MockHttpServletRequestBuilder requestBuilder;
         doReturn(createUiProfile()).when(terminologyService).getUiProfile(any(String.class));
 
-        requestBuilder = get(URI.create("/api/v3/terminology/5e6679ac-2b20-48ad-8459-f102c8944a06/ui_profile"))
+        requestBuilder = get(URI.create(PATH_API + PATH_TERMINOLOGY + "/5e6679ac-2b20-48ad-8459-f102c8944a06/ui_profile"))
                 .with(csrf());
 
         mockMvc.perform(requestBuilder)
@@ -184,7 +186,7 @@ public class TerminologyRestControllerIT {
         MockHttpServletRequestBuilder requestBuilder;
         doThrow(UiProfileNotFoundException.class).when(terminologyService).getUiProfile(any(String.class));
 
-        requestBuilder = get(URI.create("/api/v3/terminology/5e6679ac-2b20-48ad-8459-f102c8944a06/ui_profile"))
+        requestBuilder = get(URI.create(PATH_API + PATH_TERMINOLOGY + "/5e6679ac-2b20-48ad-8459-f102c8944a06/ui_profile"))
                 .with(csrf());
 
         mockMvc.perform(requestBuilder)
@@ -197,7 +199,7 @@ public class TerminologyRestControllerIT {
         MockHttpServletRequestBuilder requestBuilder;
         doReturn(createUiProfile()).when(terminologyService).getMapping(any(String.class));
 
-        requestBuilder = get(URI.create("/api/v3/terminology/5e6679ac-2b20-48ad-8459-f102c8944a06/mapping"))
+        requestBuilder = get(URI.create(PATH_API + PATH_TERMINOLOGY + "/5e6679ac-2b20-48ad-8459-f102c8944a06/mapping"))
                 .with(csrf());
 
         mockMvc.perform(requestBuilder)
@@ -211,7 +213,7 @@ public class TerminologyRestControllerIT {
         MockHttpServletRequestBuilder requestBuilder;
         doThrow(MappingNotFoundException.class).when(terminologyService).getMapping(any(String.class));
 
-        requestBuilder = get(URI.create("/api/v3/terminology/5e6679ac-2b20-48ad-8459-f102c8944a06/mapping"))
+        requestBuilder = get(URI.create(PATH_API + PATH_TERMINOLOGY + "/5e6679ac-2b20-48ad-8459-f102c8944a06/mapping"))
                 .with(csrf());
 
         mockMvc.perform(requestBuilder)
@@ -226,7 +228,7 @@ public class TerminologyRestControllerIT {
         var randomUuidListMinusOne = randomUuidList.subList(0, randomUuidList.size() - 2);
         doReturn(randomUuidListMinusOne).when(terminologyService).getIntersection(any(String.class), anyList());
 
-        requestBuilder = post(URI.create("/api/v3/terminology/criteria-set/intersect"))
+        requestBuilder = post(URI.create(PATH_API + PATH_TERMINOLOGY + "/criteria-set/intersect"))
                 .param("criteriaSetUrl", "http://foo.bar")
                 .header(HttpHeaders.CONTENT_TYPE, MediaType.APPLICATION_JSON_VALUE)
                 .content(jsonUtil.writeValueAsString(randomUuidList))

--- a/src/test/resources/application.yml
+++ b/src/test/resources/application.yml
@@ -17,6 +17,7 @@ app:
     threshold:
       sites: 3
       results: 20
+      sitesResult: 20
     quota:
       soft:
         create:


### PR DESCRIPTION
- add new variable app.privacy.threshold.sitesResult that defines the threshold a responding site must exceed in order to be configured responding in regard to the threshold for responding sites