### PR TITLE
Read measure report from task input

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -367,4 +367,13 @@
     </plugins>
   </build>
 
+  <dependencyManagement>
+    <dependencies>
+      <dependency>
+        <groupId>com.sun.xml.bind</groupId>
+        <artifactId>jaxb-impl</artifactId>
+        <version>2.3.3</version>
+      </dependency>
+    </dependencies>
+  </dependencyManagement>
 </project>

--- a/src/main/java/de/numcodex/feasibility_gui_backend/query/broker/dsf/DSFQueryResultHandler.java
+++ b/src/main/java/de/numcodex/feasibility_gui_backend/query/broker/dsf/DSFQueryResultHandler.java
@@ -109,7 +109,7 @@ class DSFQueryResultHandler {
      * @return The measure report URL.
      */
     private IdType extractMeasureReportId(Task task) {
-        Reference measureReportReference = (Reference) task.getOutput()
+        Reference measureReportReference = (Reference) task.getInput()
                 .stream()
                 .filter(o -> o.getType().getCodingFirstRep().getSystem().equals(CODE_SYSTEM_FEASIBILITY)
                         && o.getType().getCodingFirstRep().getCode().equals(CODE_SYSTEM_FEASIBILITY_VALUE_MEASURE_REPORT_REF))

--- a/src/test/java/de/numcodex/feasibility_gui_backend/query/broker/dsf/DSFQueryResultCollectorIT.java
+++ b/src/test/java/de/numcodex/feasibility_gui_backend/query/broker/dsf/DSFQueryResultCollectorIT.java
@@ -96,7 +96,7 @@ public class DSFQueryResultCollectorIT {
                                 .setCode("measure-reference")))
                 .setValue(new Reference()
                         .setReference("urn:uuid:" + UUID.randomUUID()));
-        task.addOutput()
+        task.addInput()
                 .setType(new CodeableConcept()
                         .addCoding(new Coding()
                                 .setSystem("http://medizininformatik-initiative.de/fhir/CodeSystem/feasibility")

--- a/src/test/java/de/numcodex/feasibility_gui_backend/query/broker/dsf/DSFQueryResultHandlerTest.java
+++ b/src/test/java/de/numcodex/feasibility_gui_backend/query/broker/dsf/DSFQueryResultHandlerTest.java
@@ -75,7 +75,7 @@ public class DSFQueryResultHandlerTest {
                                 .setSystem("http://dsf.dev/fhir/CodeSystem/bpmn-message")
                                 .setCode("business-key")))
                 .setValue(new StringType("1234567890"));
-        task.addOutput()
+        task.addInput()
                 .setType(new CodeableConcept()
                         .addCoding(new Coding()
                                 .setSystem("http://medizininformatik-initiative.de/fhir/CodeSystem/feasibility")
@@ -111,7 +111,7 @@ public class DSFQueryResultHandlerTest {
                                 .setSystem("http://dsf.dev/fhir/CodeSystem/bpmn-message")
                                 .setCode("business-key")))
                 .setValue(new StringType("1234567890"));
-        task.addOutput()
+        task.addInput()
                 .setType(new CodeableConcept()
                         .addCoding(new Coding()
                                 .setSystem("http://medizininformatik-initiative.de/fhir/CodeSystem/feasibility")


### PR DESCRIPTION
Measure reports are no longer stored in task outputs but in inputs now.

Additionally lock the JAXB version to 2.3.3 to maybe fix random runtime error of aktin broker not finding jaxb classes.