### PR TITLE
Fix JAXB dependency conflict

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -365,6 +365,16 @@
     </plugins>
   </build>
 
+  <dependencyManagement>
+    <dependencies>
+      <dependency>
+        <groupId>com.sun.xml.bind</groupId>
+        <artifactId>jaxb-impl</artifactId>
+        <version>2.3.3</version>
+      </dependency>
+    </dependencies>
+  </dependencyManagement>
+
   <profiles>
     <profile>
       <id>download-ontology</id>


### PR DESCRIPTION
Lock version of dependency `com.sun.xml.bind.jaxb-impl`, used by _aktin-client_  and _dsf-client_, to version `2.3.3` which is compatible to both.