### PR TITLE
#219 - Make order of UI tree categories configurable via env var

### DIFF
--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -40,6 +40,7 @@ management:
 app:
   # AKTIN or DSF or MOCK or DIRECT
   ontologyFolder: ${ONTOLOGY_FILES_FOLDER_UI:ontology/ui_trees}
+  ontologyOrder: ${ONTOLOGY_ORDER:Diagnose, Prozedur, Person, Laboruntersuchung, Medikamente, Bioprobe, Einwilligung}
   mappingsFile: ${MAPPINGS_FILE:ontology/mapping_cql.json}
   conceptTreeFile: ${CONCEPT_TREE_FILE:ontology/mapping_tree.json}
   fhirTranslationEnabled: ${FHIR_TRANSLATE_ENABLED:false}

--- a/src/test/resources/ontology/ui_profiles/CategoryA.json
+++ b/src/test/resources/ontology/ui_profiles/CategoryA.json
@@ -1,0 +1,60 @@
+{
+    "children": [
+        {
+            "context": {
+                "code": "CategoryA",
+                "display": "CategoryA",
+                "system": "fdpg.mii.cds",
+                "version": "1.0.0"
+            },
+            "display": "Termcode A_1",
+            "id": "33ca0320-81e5-406f-bdfd-c649e443ddd6",
+            "leaf": true,
+            "selectable": true,
+            "termCodes": [
+                {
+                    "code": "tcA_1",
+                    "display": "Termcode A_1",
+                    "system": "http://some.system/",
+                    "version": "http://some.system/123/version/456"
+                }
+            ]
+        },
+        {
+            "context": {
+                "code": "CategoryA",
+                "display": "CategoryA",
+                "system": "fdpg.mii.cds",
+                "version": "1.0.0"
+            },
+            "display": "Termcode A_2",
+            "id": "0da2a746-d23f-4668-9160-51d83edbd02c",
+            "leaf": true,
+            "selectable": true,
+            "termCodes": [
+                {
+                    "code": "tcA_2",
+                    "display": "Termcode A_2",
+                    "system": "http://some.system/",
+                    "version": "http://some.system/123/version/456"
+                }
+            ]
+        }
+    ],
+    "context": {
+        "code": "CategoryA",
+        "display": "CategoryA",
+        "system": "fdpg.mii.cds"
+    },
+    "display": "CategoryA",
+    "id": "30a20f30-77db-11ee-b962-0242ac120002",
+    "leaf": false,
+    "selectable": false,
+    "termCodes": [
+        {
+            "code": "CategoryA",
+            "display": "CategoryA",
+            "system": "fdpg.mii.cds"
+        }
+    ]
+}

--- a/src/test/resources/ontology/ui_profiles/CategoryB.json
+++ b/src/test/resources/ontology/ui_profiles/CategoryB.json
@@ -1,0 +1,60 @@
+{
+    "children": [
+        {
+            "context": {
+                "code": "CategoryB",
+                "display": "CategoryB",
+                "system": "fdpg.mii.cds",
+                "version": "1.0.0"
+            },
+            "display": "Termcode B_1",
+            "id": "33ca0320-81e5-406f-bdfd-c649e443ddd6",
+            "leaf": true,
+            "selectable": true,
+            "termCodes": [
+                {
+                    "code": "tcB_1",
+                    "display": "Termcode B_1",
+                    "system": "http://some.system/",
+                    "version": "http://some.system/123/version/456"
+                }
+            ]
+        },
+        {
+            "context": {
+                "code": "CategoryB",
+                "display": "CategoryB",
+                "system": "fdpg.mii.cds",
+                "version": "1.0.0"
+            },
+            "display": "Termcode B_2",
+            "id": "0da2a746-d23f-4668-9160-51d83edbd02c",
+            "leaf": true,
+            "selectable": true,
+            "termCodes": [
+                {
+                    "code": "tcB_2",
+                    "display": "Termcode B_2",
+                    "system": "http://some.system/",
+                    "version": "http://some.system/123/version/456"
+                }
+            ]
+        }
+    ],
+    "context": {
+        "code": "CategoryB",
+        "display": "CategoryB",
+        "system": "fdpg.mii.cds"
+    },
+    "display": "CategoryB",
+    "id": "385d2db8-77db-11ee-b962-0242ac120002",
+    "leaf": false,
+    "selectable": false,
+    "termCodes": [
+        {
+            "code": "CategoryB",
+            "display": "CategoryB",
+            "system": "fdpg.mii.cds"
+        }
+    ]
+}


### PR DESCRIPTION
A new application property _app.ontologyOrder_ is added and linked to the env variable _ONTOLOGY_ORDER_. It takes a comma-separated list of entries that predefine the order of the category list.

If the variable(s) should be named differently, just let me know