### PR TITLE
Avoid multiple occurrences of org.json.JSONObject on the class path

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -216,6 +216,12 @@
     <dependency>
       <groupId>org.springframework.boot</groupId>
       <artifactId>spring-boot-starter-test</artifactId>
+      <exclusions>
+        <exclusion>
+          <groupId>com.vaadin.external.google</groupId>
+          <artifactId>android-json</artifactId>
+        </exclusion>
+      </exclusions>
       <scope>test</scope>
     </dependency>
 


### PR DESCRIPTION
While running some integration tests the following message appears in the logs:
```
Found multiple occurrences of org.json.JSONObject on the class path:

	jar:file:/Users/jbellmann/.m2/repository/org/json/json/20231013/json-20231013.jar!/org/json/JSONObject.class
	jar:file:/Users/jbellmann/.m2/repository/com/vaadin/external/google/android-json/0.0.20131108.vaadin1/android-json-0.0.20131108.vaadin1.jar!/org/json/JSONObject.class

You may wish to exclude one of them to ensure predictable runtime behavior
```

This PR excludes `com.vaadin.external.google:android-json` from `spring-boot-starter-test`.