### PR TITLE
#245 - Fix swagger documentation

### DIFF
--- a/src/main/resources/static/v3/api-docs/swagger.yaml
+++ b/src/main/resources/static/v3/api-docs/swagger.yaml
@@ -823,9 +823,13 @@ components:
           format: int64
         label:
           type: string
-        created_at:
+        comment:
+          type: string
+        createdAt:
           type: string
           format: 'date-time'
+        totalNumberOfPatients:
+          type: integer
     Query:
       type: object
       required:


### PR DESCRIPTION
- add missing parameters to QueryListEntry
- fix "createdAt" parameter for QueryListEntry (is camelCase instead of snake_case)