### PR TITLE
#260 - Endpoint modification for template and savedqueries retrieval with activated validation

### DIFF
--- a/src/main/java/de/numcodex/feasibility_gui_backend/query/api/QueryListEntry.java
+++ b/src/main/java/de/numcodex/feasibility_gui_backend/query/api/QueryListEntry.java
@@ -3,9 +3,11 @@ package de.numcodex.feasibility_gui_backend.query.api;
 import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonInclude.Include;
 import com.fasterxml.jackson.annotation.JsonProperty;
+import de.numcodex.feasibility_gui_backend.common.api.TermCode;
 import lombok.Builder;
 
 import java.sql.Timestamp;
+import java.util.List;
 
 @JsonInclude(Include.NON_NULL)
 @Builder
@@ -14,7 +16,8 @@ public record QueryListEntry(
     @JsonProperty String label,
     @JsonProperty String comment,
     @JsonProperty Timestamp createdAt,
-    @JsonProperty Long totalNumberOfPatients
+    @JsonProperty Long totalNumberOfPatients,
+    @JsonProperty List<TermCode> invalidTerms
 )  {
 
 }

--- a/src/main/java/de/numcodex/feasibility_gui_backend/query/v3/QueryHandlerRestController.java
+++ b/src/main/java/de/numcodex/feasibility_gui_backend/query/v3/QueryHandlerRestController.java
@@ -185,11 +185,12 @@ public class QueryHandlerRestController {
   @GetMapping("")
   public List<QueryListEntry> getQueryList(
       @RequestParam(name = "filter", required = false) String filter,
+      @RequestParam(value = "skipValidation", required = false, defaultValue = "false") boolean skipValidation,
       Principal principal) {
     var userId = principal.getName();
     var savedOnly = (filter != null && filter.equalsIgnoreCase("saved"));
     var queryList = queryHandlerService.getQueryListForAuthor(userId, savedOnly);
-    return queryHandlerService.convertQueriesToQueryListEntries(queryList);
+    return queryHandlerService.convertQueriesToQueryListEntries(queryList, skipValidation);
   }
 
   @PostMapping("/{id}/saved")
@@ -296,7 +297,7 @@ public class QueryHandlerRestController {
       @RequestParam(name = "filter", required = false) String filter) {
     var savedOnly = (filter != null && filter.equalsIgnoreCase("saved"));
     var queryList =  queryHandlerService.getQueryListForAuthor(userId, savedOnly);
-    return queryHandlerService.convertQueriesToQueryListEntries(queryList);
+    return queryHandlerService.convertQueriesToQueryListEntries(queryList, true);
   }
 
   @GetMapping("/{id}")

--- a/src/main/resources/static/v3/api-docs/swagger.yaml
+++ b/src/main/resources/static/v3/api-docs/swagger.yaml
@@ -87,6 +87,13 @@ paths:
             type: string
             enum:
               - saved
+        - name: skipValidation
+          in: query
+          description: If true, do not validate the query and do not include a list of invalid terms
+          required: false
+          schema:
+            type: boolean
+            default: false
       responses:
         200:
           description: successful operation
@@ -505,6 +512,14 @@ paths:
       summary: Read list of query templates
       description: Returns the list of all query templates of the current user
       operationId: getQueryTemplateList
+      parameters:
+        - name: skipValidation
+          in: query
+          description: If true, do not validate the query and do not include a list of invalid terms
+          required: false
+          schema:
+            type: boolean
+            default: false
       responses:
         200:
           description: OK
@@ -612,27 +627,6 @@ paths:
       security:
         - feasibility_auth:
             - user
-  /query/template/validate:
-    get:
-      tags:
-        - templates
-      summary: Check all own query templates for invalid or outdated termcodes
-      description: Returns a list of query templates with the additional info if a query is valid
-      operationId: validateQueryTemplateList
-      responses:
-        200:
-          description: OK
-          content:
-            application/json:
-              schema:
-                items:
-                  $ref: '#/components/schemas/QueryTemplate'
-        401:
-          description: Unauthorized - please login first
-          content: { }
-      security:
-        - feasibility_auth:
-            - read:query
   /terminology/categories:
     get:
       tags:
@@ -817,6 +811,7 @@ components:
       required:
         - id
         - label
+        - invalidTerms
       properties:
         id:
           type: integer
@@ -830,6 +825,10 @@ components:
           format: 'date-time'
         totalNumberOfPatients:
           type: integer
+        invalidTerms:
+          type: array
+          items:
+            $ref: "#/components/schemas/TermCode"
     Query:
       type: object
       required:
@@ -912,6 +911,7 @@ components:
       type: object
       required:
         - label
+        - invalidTerms
       properties:
         id:
           type: integer
@@ -930,6 +930,13 @@ components:
         createdBy:
           type: string
           description: Keycloak id of the user who created the query
+        invalidTerms:
+          type: array
+          items:
+            $ref: "#/components/schemas/TermCode"
+        isValid:
+          type: boolean
+          description: is the query valid?
     QueryTemplate:
       type: object
       required:

--- a/src/test/java/de/numcodex/feasibility_gui_backend/query/QueryHandlerServiceIT.java
+++ b/src/test/java/de/numcodex/feasibility_gui_backend/query/QueryHandlerServiceIT.java
@@ -24,16 +24,17 @@ import de.numcodex.feasibility_gui_backend.query.translation.QueryTranslatorSpri
 import java.net.URI;
 import java.util.List;
 
+import de.numcodex.feasibility_gui_backend.terminology.validation.TermCodeValidation;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.EnumSource;
-import org.mockito.Spy;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.boot.test.autoconfigure.jdbc.AutoConfigureTestDatabase;
 import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
 import org.springframework.context.annotation.Import;
 import org.springframework.dao.DataIntegrityViolationException;
 import org.testcontainers.junit.jupiter.Testcontainers;
@@ -99,6 +100,9 @@ public class QueryHandlerServiceIT {
 
     @Autowired
     private QueryHashCalculator queryHashCalculator;
+
+    @MockBean
+    private TermCodeValidation termCodeValidation;
 
     @Autowired
     @Qualifier("translation")

--- a/src/test/java/de/numcodex/feasibility_gui_backend/terminology/v3/TerminologyRestControllerIT.java
+++ b/src/test/java/de/numcodex/feasibility_gui_backend/terminology/v3/TerminologyRestControllerIT.java
@@ -16,7 +16,6 @@ import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.junit.jupiter.params.ParameterizedTest;
-import org.junit.jupiter.params.provider.CsvSource;
 import org.junit.jupiter.params.provider.ValueSource;
 import org.mockito.Mockito;
 import org.springframework.beans.factory.annotation.Autowired;


### PR DESCRIPTION
* Modify the endpoints to retrieve query and query templates list. By default, always include validation of the queries (can be disabled via request parameter "skipValidation" (defaults to false)
* Remove /template/validate endpoint

 :warning: We discussed whether or not this should lead to a new api version (v4), but it was decided against doing so, even if it technically is not correct. :warning: 