### PR TITLE
#258 - Add an endpoint that takes a structured query and validates it

### DIFF
--- a/src/main/java/de/numcodex/feasibility_gui_backend/query/QueryHandlerService.java
+++ b/src/main/java/de/numcodex/feasibility_gui_backend/query/QueryHandlerService.java
@@ -2,7 +2,7 @@ package de.numcodex.feasibility_gui_backend.query;
 
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
-import de.numcodex.feasibility_gui_backend.common.api.TermCode;
+import de.numcodex.feasibility_gui_backend.common.api.Criterion;
 import de.numcodex.feasibility_gui_backend.query.api.Query;
 import de.numcodex.feasibility_gui_backend.query.api.QueryTemplate;
 import de.numcodex.feasibility_gui_backend.query.api.SavedQuery;
@@ -242,15 +242,15 @@ public class QueryHandlerService {
 
     public QueryListEntry convertQueryToQueryListEntry(de.numcodex.feasibility_gui_backend.query.persistence.Query query,
                                                        boolean skipValidation) {
-        List<TermCode> invalidTermCodes;
+        List<Criterion> invalidCriteria;
         if (skipValidation) {
-            invalidTermCodes = List.of();
+            invalidCriteria = List.of();
         } else {
           try {
             var sq = jsonUtil.readValue(query.getQueryContent().getQueryContent(), StructuredQuery.class);
-            invalidTermCodes = termCodeValidation.getInvalidTermCodes(sq);
+              invalidCriteria = termCodeValidation.getInvalidCriteria(sq);
           } catch (JsonProcessingException e) {
-              invalidTermCodes = List.of();
+              invalidCriteria = List.of();
           }
         }
 
@@ -262,14 +262,14 @@ public class QueryHandlerService {
                     .comment(query.getSavedQuery().getComment())
                     .totalNumberOfPatients(query.getSavedQuery().getResultSize())
                     .createdAt(query.getCreatedAt())
-                    .invalidTerms(invalidTermCodes)
+                    .invalidCriteria(invalidCriteria)
                     .build();
         } else {
             return
                 QueryListEntry.builder()
                     .id(query.getId())
                     .createdAt(query.getCreatedAt())
-                    .invalidTerms(invalidTermCodes)
+                    .invalidCriteria(invalidCriteria)
                     .build();
         }
     }

--- a/src/main/java/de/numcodex/feasibility_gui_backend/query/api/Query.java
+++ b/src/main/java/de/numcodex/feasibility_gui_backend/query/api/Query.java
@@ -3,7 +3,7 @@ package de.numcodex.feasibility_gui_backend.query.api;
 import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonInclude.Include;
 import com.fasterxml.jackson.annotation.JsonProperty;
-import de.numcodex.feasibility_gui_backend.common.api.TermCode;
+import de.numcodex.feasibility_gui_backend.common.api.Criterion;
 import lombok.Builder;
 
 import java.util.List;
@@ -15,7 +15,7 @@ public record Query(
     @JsonProperty StructuredQuery content,
     @JsonProperty String label,
     @JsonProperty String comment,
-    @JsonProperty List<TermCode> invalidTerms
+    @JsonProperty List<Criterion> invalidCriteria
 ) {
 
 }

--- a/src/main/java/de/numcodex/feasibility_gui_backend/query/api/QueryListEntry.java
+++ b/src/main/java/de/numcodex/feasibility_gui_backend/query/api/QueryListEntry.java
@@ -3,7 +3,7 @@ package de.numcodex.feasibility_gui_backend.query.api;
 import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonInclude.Include;
 import com.fasterxml.jackson.annotation.JsonProperty;
-import de.numcodex.feasibility_gui_backend.common.api.TermCode;
+import de.numcodex.feasibility_gui_backend.common.api.Criterion;
 import lombok.Builder;
 
 import java.sql.Timestamp;
@@ -17,7 +17,7 @@ public record QueryListEntry(
     @JsonProperty String comment,
     @JsonProperty Timestamp createdAt,
     @JsonProperty Long totalNumberOfPatients,
-    @JsonProperty List<TermCode> invalidTerms
+    @JsonProperty List<Criterion> invalidCriteria
 )  {
 
 }

--- a/src/main/java/de/numcodex/feasibility_gui_backend/query/api/QueryTemplate.java
+++ b/src/main/java/de/numcodex/feasibility_gui_backend/query/api/QueryTemplate.java
@@ -3,7 +3,7 @@ package de.numcodex.feasibility_gui_backend.query.api;
 import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonInclude.Include;
 import com.fasterxml.jackson.annotation.JsonProperty;
-import de.numcodex.feasibility_gui_backend.common.api.TermCode;
+import de.numcodex.feasibility_gui_backend.common.api.Criterion;
 import de.numcodex.feasibility_gui_backend.query.api.validation.QueryTemplateValidation;
 import lombok.Builder;
 
@@ -19,7 +19,7 @@ public record QueryTemplate(
     @JsonProperty String comment,
     @JsonProperty String lastModified,
     @JsonProperty String createdBy,
-    @JsonProperty List<TermCode> invalidTerms,
+    @JsonProperty List<Criterion> invalidCriteria,
     @JsonProperty Boolean isValid
 ) {
 

--- a/src/main/java/de/numcodex/feasibility_gui_backend/query/api/StructuredQuery.java
+++ b/src/main/java/de/numcodex/feasibility_gui_backend/query/api/StructuredQuery.java
@@ -4,6 +4,7 @@ import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonInclude.Include;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import de.numcodex.feasibility_gui_backend.common.api.Criterion;
+import de.numcodex.feasibility_gui_backend.common.api.TermCode;
 import de.numcodex.feasibility_gui_backend.query.api.validation.StructuredQueryValidation;
 import lombok.Builder;
 

--- a/src/main/java/de/numcodex/feasibility_gui_backend/query/api/ValidatedStructuredQuery.java
+++ b/src/main/java/de/numcodex/feasibility_gui_backend/query/api/ValidatedStructuredQuery.java
@@ -1,0 +1,15 @@
+package de.numcodex.feasibility_gui_backend.query.api;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import de.numcodex.feasibility_gui_backend.common.api.Criterion;
+import lombok.Builder;
+
+import java.util.List;
+
+@Builder
+public record ValidatedStructuredQuery(
+    @JsonProperty StructuredQuery query,
+    @JsonProperty List<Criterion> invalidCriteria
+) {
+
+}

--- a/src/main/java/de/numcodex/feasibility_gui_backend/query/api/validation/StructuredQueryValidator.java
+++ b/src/main/java/de/numcodex/feasibility_gui_backend/query/api/validation/StructuredQueryValidator.java
@@ -13,6 +13,8 @@ import jakarta.validation.ConstraintValidator;
 import jakarta.validation.ConstraintValidatorContext;
 import org.springframework.beans.factory.annotation.Qualifier;
 
+import java.util.stream.Collectors;
+
 /**
  * Validator for {@link StructuredQuery} that does an actual check based on a JSON schema.
  */
@@ -47,8 +49,11 @@ public class StructuredQueryValidator implements ConstraintValidator<StructuredQ
       var jsonSubject = new JSONObject(jsonUtil.writeValueAsString(structuredQuery));
       jsonSchema.validate(jsonSubject);
       return true;
-    } catch (ValidationException | JsonProcessingException e) {
-      log.debug("Structured query is invalid", e);
+    } catch (ValidationException e) {
+      log.error("Structured query is invalid: {}", e.getCausingExceptions().stream().map(Throwable::getMessage).collect(Collectors.joining(" ## ")));
+      return false;
+    } catch (JsonProcessingException jpe) {
+      log.debug("Could not process JSON", jpe);
       return false;
     }
   }

--- a/src/main/java/de/numcodex/feasibility_gui_backend/query/v3/QueryHandlerRestController.java
+++ b/src/main/java/de/numcodex/feasibility_gui_backend/query/v3/QueryHandlerRestController.java
@@ -1,6 +1,7 @@
 package de.numcodex.feasibility_gui_backend.query.v3;
 
 import com.fasterxml.jackson.core.JsonProcessingException;
+import de.numcodex.feasibility_gui_backend.common.api.Criterion;
 import de.numcodex.feasibility_gui_backend.common.api.TermCode;
 import de.numcodex.feasibility_gui_backend.config.WebSecurityConfig;
 import de.numcodex.feasibility_gui_backend.query.QueryHandlerService;
@@ -302,15 +303,15 @@ public class QueryHandlerRestController {
       return new ResponseEntity<>(HttpStatus.FORBIDDEN);
     }
     var query = queryHandlerService.getQuery(queryId);
-    List<TermCode> invalidTermCodes = termCodeValidation.getInvalidTermCodes(query.content());
-    var queryWithInvalidTerms = Query.builder()
+    List<Criterion> invalidCriteria = termCodeValidation.getInvalidCriteria(query.content());
+    var queryWithInvalidCriteria = Query.builder()
             .id(query.id())
             .content(query.content())
             .label(query.label())
             .comment(query.comment())
-            .invalidTerms(invalidTermCodes)
+            .invalidCriteria(invalidCriteria)
             .build();
-    return new ResponseEntity<>(queryWithInvalidTerms, HttpStatus.OK);
+    return new ResponseEntity<>(queryWithInvalidCriteria, HttpStatus.OK);
   }
 
   @GetMapping("/{id}" + WebSecurityConfig.PATH_DETAILED_RESULT)

--- a/src/main/java/de/numcodex/feasibility_gui_backend/query/v3/QueryHandlerRestController.java
+++ b/src/main/java/de/numcodex/feasibility_gui_backend/query/v3/QueryHandlerRestController.java
@@ -6,12 +6,7 @@ import de.numcodex.feasibility_gui_backend.config.WebSecurityConfig;
 import de.numcodex.feasibility_gui_backend.query.QueryHandlerService;
 import de.numcodex.feasibility_gui_backend.query.QueryHandlerService.ResultDetail;
 import de.numcodex.feasibility_gui_backend.query.QueryNotFoundException;
-import de.numcodex.feasibility_gui_backend.query.api.Query;
-import de.numcodex.feasibility_gui_backend.query.api.QueryListEntry;
-import de.numcodex.feasibility_gui_backend.query.api.QueryResult;
-import de.numcodex.feasibility_gui_backend.query.api.QueryResultRateLimit;
-import de.numcodex.feasibility_gui_backend.query.api.SavedQuery;
-import de.numcodex.feasibility_gui_backend.query.api.StructuredQuery;
+import de.numcodex.feasibility_gui_backend.query.api.*;
 import de.numcodex.feasibility_gui_backend.query.api.status.FeasibilityIssue;
 import de.numcodex.feasibility_gui_backend.query.api.status.FeasibilityIssues;
 import de.numcodex.feasibility_gui_backend.query.api.status.SavedQuerySlots;
@@ -404,9 +399,14 @@ public class QueryHandlerRestController {
   }
 
   @PostMapping("/validate")
-  public ResponseEntity<Object> validateStructuredQuery(
+  public ResponseEntity<ValidatedStructuredQuery> validateStructuredQuery(
       @Valid @RequestBody StructuredQuery query) {
-    return new ResponseEntity<>(HttpStatus.NO_CONTENT);
+    var invalidCriteria = termCodeValidation.getInvalidCriteria(query);
+    var validatedQuery = ValidatedStructuredQuery.builder()
+        .query(query)
+        .invalidCriteria(invalidCriteria)
+        .build();
+    return new ResponseEntity<>(validatedQuery, HttpStatus.OK);
   }
 
   private boolean hasAccess(Long queryId, Authentication authentication) {

--- a/src/main/java/de/numcodex/feasibility_gui_backend/query/v3/QueryTemplateHandlerRestController.java
+++ b/src/main/java/de/numcodex/feasibility_gui_backend/query/v3/QueryTemplateHandlerRestController.java
@@ -1,6 +1,7 @@
 package de.numcodex.feasibility_gui_backend.query.v3;
 
 import com.fasterxml.jackson.core.JsonProcessingException;
+import de.numcodex.feasibility_gui_backend.common.api.Criterion;
 import de.numcodex.feasibility_gui_backend.common.api.TermCode;
 import de.numcodex.feasibility_gui_backend.query.QueryHandlerService;
 import de.numcodex.feasibility_gui_backend.query.api.QueryTemplate;
@@ -76,19 +77,19 @@ public class QueryTemplateHandlerRestController {
     try {
       var query = queryHandlerService.getQueryTemplate(queryId, principal.getName());
       var queryTemplate = queryHandlerService.convertTemplatePersistenceToApi(query);
-      List<TermCode> invalidTermCodes = termCodeValidation.getInvalidTermCodes(
+      List<Criterion> invalidCriteria = termCodeValidation.getInvalidCriteria(
           queryTemplate.content());
-      var queryTemplateWithInvalidTermCodes = QueryTemplate.builder()
+      var queryTemplateWithInvalidCritiera = QueryTemplate.builder()
               .id(queryTemplate.id())
               .content(queryTemplate.content())
               .label(queryTemplate.label())
               .comment(queryTemplate.comment())
               .lastModified(queryTemplate.lastModified())
               .createdBy(queryTemplate.createdBy())
-              .invalidTerms(invalidTermCodes)
+              .invalidCriteria(invalidCriteria)
               .isValid(queryTemplate.isValid())
               .build();
-      return new ResponseEntity<>(queryTemplateWithInvalidTermCodes, HttpStatus.OK);
+      return new ResponseEntity<>(queryTemplateWithInvalidCritiera, HttpStatus.OK);
     } catch (JsonProcessingException e) {
       return new ResponseEntity<>(HttpStatus.INTERNAL_SERVER_ERROR);
     } catch (QueryTemplateException e) {
@@ -106,11 +107,11 @@ public class QueryTemplateHandlerRestController {
     queries.forEach(q -> {
       try {
         QueryTemplate convertedQuery = queryHandlerService.convertTemplatePersistenceToApi(q);
-        List<TermCode> invalidTermCodes;
+        List<Criterion> invalidCriteria;
         if (skipValidation) {
-          invalidTermCodes = List.of();
+          invalidCriteria = List.of();
         } else {
-          invalidTermCodes = termCodeValidation.getInvalidTermCodes(
+          invalidCriteria = termCodeValidation.getInvalidCriteria(
               convertedQuery.content());
         }
         var convertedQueryWithoutContent = QueryTemplate.builder()
@@ -119,7 +120,7 @@ public class QueryTemplateHandlerRestController {
             .comment(convertedQuery.comment())
             .lastModified(convertedQuery.lastModified())
             .createdBy(convertedQuery.createdBy())
-            .invalidTerms(invalidTermCodes)
+            .invalidCriteria(invalidCriteria)
             .isValid(convertedQuery.isValid())
             .build();
         ret.add(convertedQueryWithoutContent);

--- a/src/main/java/de/numcodex/feasibility_gui_backend/terminology/validation/TermCodeValidation.java
+++ b/src/main/java/de/numcodex/feasibility_gui_backend/terminology/validation/TermCodeValidation.java
@@ -23,46 +23,6 @@ public class TermCodeValidation {
     this.terminologyService = terminologyService;
   }
 
-  /**
-   * Check a structured query for invalid/outdated termcodes.
-   *
-   * For now, just check if the term codes still exist in the current ui profiles. Further
-   * iterations may contain checking for availability of values and units of the term codes as well.
-   *
-   * @param structuredQuery the structured query to check
-   * @return a list of term codes that are no longer valid (or have never been)
-   */
-  public List<TermCode> getInvalidTermCodes(StructuredQuery structuredQuery) {
-    var invalidTermCodes = new ArrayList<TermCode>();
-
-    List<List<Criterion>> combinedCriteria;
-
-    if (structuredQuery.exclusionCriteria() != null && !structuredQuery.exclusionCriteria().isEmpty()) {
-      combinedCriteria = Stream.of(
-          structuredQuery.inclusionCriteria(),
-          structuredQuery.exclusionCriteria()).flatMap(
-          Collection::stream).toList();
-    } else {
-      combinedCriteria = structuredQuery.inclusionCriteria();
-    }
-
-    for (List<Criterion> criterionList : combinedCriteria) {
-      for (Criterion criterion : criterionList) {
-        for (TermCode termCode : criterion.termCodes()) {
-          if (terminologyService.isExistingTermCode(termCode.system(), termCode.code(), termCode.version())) {
-            log.trace("termcode ok: {} - {} - {}", termCode.system(), termCode.code(), termCode.version());
-          } else {
-            log.debug("termcode invalid: {} - {} - {}", termCode.system(), termCode.code(),
-                    termCode.version());
-            invalidTermCodes.add(termCode);
-          }
-        }
-      }
-    }
-
-    return invalidTermCodes;
-  }
-
   private Criterion removeFilters(Criterion in) {
     return Criterion.builder()
         .termCodes(in.termCodes())
@@ -70,6 +30,15 @@ public class TermCodeValidation {
         .build();
   }
 
+  /**
+   * Check a structured query for invalid/outdated termcodes in criteria.
+   *
+   * For now, just check if the term codes still exist in the current ui profiles. Further
+   * iterations may contain checking for availability of values and units of the term codes as well.
+   *
+   * @param structuredQuery the structured query to check
+   * @return a list of criteria that are no longer valid (or have never been)
+   */
   public List<Criterion> getInvalidCriteria(StructuredQuery structuredQuery) {
     var invalidCriteria = new ArrayList<Criterion>();
 

--- a/src/main/resources/de/numcodex/feasibility_gui_backend/query/api/validation/query-template-schema.json
+++ b/src/main/resources/de/numcodex/feasibility_gui_backend/query/api/validation/query-template-schema.json
@@ -26,11 +26,11 @@
       "type": "string",
       "description": "The user id in the authentication service of the user that created the query."
     },
-    "invalidTerms": {
+    "invalidCriteria": {
       "type": "array",
-      "description": "An array of Terms that did not pass validation. This is only filled when reading from the backend.",
+      "description": "An array of Criteria that did not pass validation. This is only filled when reading from the backend.",
       "items": {
-        "$ref": "query-schema.json#/definitions/termCode"
+        "$ref": "query-schema.json#/definitions/criterion"
       }
     }
   },

--- a/src/main/resources/static/v3/api-docs/swagger.yaml
+++ b/src/main/resources/static/v3/api-docs/swagger.yaml
@@ -840,7 +840,7 @@ components:
       required:
         - id
         - label
-        - invalidTerms
+        - invalidCriteria
       properties:
         id:
           type: integer
@@ -854,10 +854,10 @@ components:
           format: 'date-time'
         totalNumberOfPatients:
           type: integer
-        invalidTerms:
+        invalidCriteria:
           type: array
           items:
-            $ref: "#/components/schemas/TermCode"
+            $ref: "#/components/schemas/Criterion"
     Query:
       type: object
       required:
@@ -873,10 +873,10 @@ components:
           type: string
         results:
           $ref: "#/components/schemas/QueryResult"
-        invalidTerms:
+        invalidCriteria:
           type: array
           items:
-            $ref: "#/components/schemas/TermCode"
+            $ref: "#/components/schemas/Criterion"
     QueryResultSummary:
       type: object
       properties:
@@ -940,7 +940,7 @@ components:
       type: object
       required:
         - label
-        - invalidTerms
+        - invalidCriteria
       properties:
         id:
           type: integer
@@ -959,10 +959,10 @@ components:
         createdBy:
           type: string
           description: Keycloak id of the user who created the query
-        invalidTerms:
+        invalidCriteria:
           type: array
           items:
-            $ref: "#/components/schemas/TermCode"
+            $ref: "#/components/schemas/Criterion"
         isValid:
           type: boolean
           description: is the query valid?
@@ -990,10 +990,10 @@ components:
         createdBy:
           type: string
           description: Keycloak id of the user who created the query
-        invalidTerms:
+        invalidCriteria:
           type: array
           items:
-            $ref: "#/components/schemas/TermCode"
+            $ref: "#/components/schemas/Criterion"
     StructuredQuery:
       type: object
       required:
@@ -1020,14 +1020,14 @@ components:
       type: object
       required:
         - query
-        - invalidTerms
+        - invalidCriteria
       properties:
         query:
           $ref: "#/components/schemas/StructuredQuery"
-        invalidTerms:
+        invalidCriteria:
           type: array
           items:
-            $ref: "#/components/schemas/TermCode"
+            $ref: "#/components/schemas/Criterion"
     SavedQuery:
       type: object
       required:

--- a/src/main/resources/static/v3/api-docs/swagger.yaml
+++ b/src/main/resources/static/v3/api-docs/swagger.yaml
@@ -109,6 +109,35 @@ paths:
       security:
         - feasibility_auth:
             - user
+  /query/validate:
+    post:
+      tags:
+        - query
+        - validation
+      summary: Validates a submitted (structured) query to check for schema violations or invalid termCodes
+      operationId: validateQuery
+      requestBody:
+        description: Structured query to validate
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/StructuredQuery'
+        required: true
+      responses:
+        200:
+          description: Query adheres to json schema. If invalid termCodes are present, they will be in the response.
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  $ref: '#/components/schemas/ValidatedStructuredQuery'
+        400:
+          description: Query does not adhere to json schema
+          content: { }
+        401:
+          description: Unauthorized - please login first
+          content: { }
   /query/by-user/{userId}:
     get:
       tags:
@@ -987,6 +1016,18 @@ components:
           type: array
           items:
             $ref: "#/components/schemas/CriterionList"
+    ValidatedStructuredQuery:
+      type: object
+      required:
+        - query
+        - invalidTerms
+      properties:
+        query:
+          $ref: "#/components/schemas/StructuredQuery"
+        invalidTerms:
+          type: array
+          items:
+            $ref: "#/components/schemas/TermCode"
     SavedQuery:
       type: object
       required:

--- a/src/test/java/de/numcodex/feasibility_gui_backend/query/QueryHandlerServiceTest.java
+++ b/src/test/java/de/numcodex/feasibility_gui_backend/query/QueryHandlerServiceTest.java
@@ -112,12 +112,9 @@ class QueryHandlerServiceTest {
     void convertQueriesToQueryListEntries(String withSavedQuery, String skipValidation) throws JsonProcessingException {
         var queryList = List.of(createQuery(Boolean.parseBoolean(withSavedQuery)));
         if (!Boolean.parseBoolean(skipValidation)) {
-            doReturn(List.of(TermCode.builder()
-                .code("LL2191-6")
-                .system("http://loinc.org")
-                .display("Geschlecht")
-                .build()
-            )).when(termCodeValidation).getInvalidTermCodes(any(StructuredQuery.class));
+            doReturn(
+                List.of(createInvalidCriterion())
+            ).when(termCodeValidation).getInvalidCriteria(any(StructuredQuery.class));
         }
 
         List<QueryListEntry> queryListEntries = queryHandlerService.convertQueriesToQueryListEntries(queryList, Boolean.parseBoolean(skipValidation));
@@ -130,9 +127,9 @@ class QueryHandlerServiceTest {
             assertThat(queryListEntries.get(0).totalNumberOfPatients()).isEqualTo(RESULT_SIZE);
         }
         if (Boolean.parseBoolean(skipValidation)) {
-            assertThat(queryListEntries.get(0).invalidTerms().size()).isEqualTo(0);
+            assertThat(queryListEntries.get(0).invalidCriteria().size()).isEqualTo(0);
         } else {
-            assertThat(queryListEntries.get(0).invalidTerms().size()).isEqualTo(1);
+            assertThat(queryListEntries.get(0).invalidCriteria().size()).isEqualTo(1);
         }
     }
 
@@ -146,7 +143,7 @@ class QueryHandlerServiceTest {
         assertThat(queryListEntries.size()).isEqualTo(1);
         assertThat(queryListEntries.get(0).id()).isEqualTo(QUERY_ID);
         assertThat(queryListEntries.get(0).createdAt()).isEqualTo(LAST_MODIFIED);
-        assertThat(queryListEntries.get(0).invalidTerms().size()).isEqualTo(0);
+        assertThat(queryListEntries.get(0).invalidCriteria().size()).isEqualTo(0);
     }
 
     private Query createQuery(boolean withSavedQuery) throws JsonProcessingException {
@@ -194,5 +191,17 @@ class QueryHandlerServiceTest {
                 .exclusionCriteria(List.of())
                 .display("foo")
                 .build();
+    }
+
+    private Criterion createInvalidCriterion() {
+        var termCode = TermCode.builder()
+            .code("LL2191-6")
+            .system("http://loinc.org")
+            .display("Geschlecht")
+            .build();
+        return Criterion.builder()
+            .context(null)
+            .termCodes(List.of(termCode))
+            .build();
     }
 }

--- a/src/test/java/de/numcodex/feasibility_gui_backend/query/api/validation/QueryTemplateValidatorTest.java
+++ b/src/test/java/de/numcodex/feasibility_gui_backend/query/api/validation/QueryTemplateValidatorTest.java
@@ -123,7 +123,7 @@ public class QueryTemplateValidatorTest {
             .comment(validQuery.comment())
             .lastModified(validQuery.lastModified())
             .createdBy(validQuery.createdBy())
-            .invalidTerms(validQuery.invalidTerms())
+            .invalidCriteria(validQuery.invalidCriteria())
             .isValid(validQuery.isValid())
             .build();
   }
@@ -136,7 +136,7 @@ public class QueryTemplateValidatorTest {
             .comment(validQuery.comment())
             .lastModified(validQuery.lastModified())
             .createdBy(validQuery.createdBy())
-            .invalidTerms(validQuery.invalidTerms())
+            .invalidCriteria(validQuery.invalidCriteria())
             .isValid(validQuery.isValid())
             .build();
   }
@@ -155,7 +155,7 @@ public class QueryTemplateValidatorTest {
             .comment(validQuery.comment())
             .lastModified(validQuery.lastModified())
             .createdBy(validQuery.createdBy())
-            .invalidTerms(validQuery.invalidTerms())
+            .invalidCriteria(validQuery.invalidCriteria())
             .isValid(validQuery.isValid())
             .build();
   }

--- a/src/test/java/de/numcodex/feasibility_gui_backend/query/broker/direct/DirectBrokerClientCqlIT.java
+++ b/src/test/java/de/numcodex/feasibility_gui_backend/query/broker/direct/DirectBrokerClientCqlIT.java
@@ -42,7 +42,7 @@ class DirectBrokerClientCqlIT {
     private static final Long TEST_BACKEND_QUERY_ID = 1L;
 
     private final GenericContainer<?> blaze = new GenericContainer<>(
-        DockerImageName.parse("samply/blaze:0.18"))
+        DockerImageName.parse("samply/blaze:0.25"))
         .withImagePullPolicy(PullPolicy.alwaysPull())
         .withExposedPorts(8080)
         .waitingFor(Wait.forHttp("/health").forStatusCodeMatching(c -> c >= 200 && c <= 500))

--- a/src/test/java/de/numcodex/feasibility_gui_backend/query/broker/dsf/DSFFhirWebClientProviderTest.java
+++ b/src/test/java/de/numcodex/feasibility_gui_backend/query/broker/dsf/DSFFhirWebClientProviderTest.java
@@ -19,7 +19,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 public class DSFFhirWebClientProviderTest {
 
     @Container
-    private GenericContainer<?> blaze = new GenericContainer<>("samply/blaze:0.23.3")
+    private GenericContainer<?> blaze = new GenericContainer<>("samply/blaze:0.25")
             .withExposedPorts(8080)
             .withNetwork(Network.newNetwork())
             .withReuse(true);

--- a/src/test/java/de/numcodex/feasibility_gui_backend/query/v3/QueryHandlerRestControllerIT.java
+++ b/src/test/java/de/numcodex/feasibility_gui_backend/query/v3/QueryHandlerRestControllerIT.java
@@ -130,7 +130,7 @@ public class QueryHandlerRestControllerIT {
         StructuredQuery testQuery = createValidStructuredQuery();
 
         doReturn(Mono.just(1L)).when(queryHandlerService).runQuery(any(StructuredQuery.class), eq("test"));
-        doReturn(List.of()).when(termCodeValidation).getInvalidTermCodes(any(StructuredQuery.class));
+        doReturn(List.of()).when(termCodeValidation).getInvalidCriteria(any(StructuredQuery.class));
 
         var mvcResult = mockMvc.perform(post(URI.create(PATH_API + PATH_QUERY)).with(csrf())
                         .contentType(APPLICATION_JSON)
@@ -152,7 +152,7 @@ public class QueryHandlerRestControllerIT {
         var dispatchError = new QueryDispatchException("something went wrong");
 
         doReturn(Mono.error(dispatchError)).when(queryHandlerService).runQuery(any(StructuredQuery.class), eq("test"));
-        doReturn(List.of()).when(termCodeValidation).getInvalidTermCodes(any(StructuredQuery.class));
+        doReturn(List.of()).when(termCodeValidation).getInvalidCriteria(any(StructuredQuery.class));
 
         var mvcResult = mockMvc.perform(post(URI.create(PATH_API + PATH_QUERY)).with(csrf())
                         .contentType(APPLICATION_JSON)
@@ -170,7 +170,7 @@ public class QueryHandlerRestControllerIT {
         StructuredQuery testQuery = createValidStructuredQuery();
 
         doReturn((long)quotaSoftCreateAmount + 1).when(queryHandlerService).getAmountOfQueriesByUserAndInterval(any(String.class), any(Integer.class));
-        doReturn(List.of()).when(termCodeValidation).getInvalidTermCodes(any(StructuredQuery.class));
+        doReturn(List.of()).when(termCodeValidation).getInvalidCriteria(any(StructuredQuery.class));
 
         var mvcResult = mockMvc.perform(post(URI.create(PATH_API + PATH_QUERY)).with(csrf())
                         .contentType(APPLICATION_JSON)
@@ -187,7 +187,7 @@ public class QueryHandlerRestControllerIT {
     public void testValidateQueryEndpoint_SucceedsOnValidQuery() throws Exception {
         StructuredQuery testQuery = createValidStructuredQuery();
 
-        doReturn(List.of()).when(termCodeValidation).getInvalidTermCodes(any(StructuredQuery.class));
+        doReturn(List.of()).when(termCodeValidation).getInvalidCriteria(any(StructuredQuery.class));
 
         mockMvc.perform(post(URI.create(PATH_API + PATH_QUERY + "/validate")).with(csrf())
                 .contentType(APPLICATION_JSON)
@@ -198,7 +198,7 @@ public class QueryHandlerRestControllerIT {
 
     @Test
     @WithMockUser(roles = "FEASIBILITY_TEST_USER")
-    public void testValidateQueryEndpoint_SucceedsDespiteInvalidTermcodesWith200() throws Exception {
+    public void testValidateQueryEndpoint_SucceedsDespiteInvalidCriteriaWith200() throws Exception {
         StructuredQuery testQuery = createValidStructuredQuery();
         var invalidCriterion = createInvalidCriterion();
 
@@ -223,7 +223,7 @@ public class QueryHandlerRestControllerIT {
         Optional<UserBlacklist> userBlacklistOptional = Optional.of(userBlacklistEntry);
         doReturn(userBlacklistOptional).when(userBlacklistRepository).findByUserId(any(String.class));
         doReturn(Mono.just(1L)).when(queryHandlerService).runQuery(any(StructuredQuery.class), eq("test"));
-        doReturn(List.of()).when(termCodeValidation).getInvalidTermCodes(any(StructuredQuery.class));
+        doReturn(List.of()).when(termCodeValidation).getInvalidCriteria(any(StructuredQuery.class));
 
         var mvcResult = mockMvc.perform(post(URI.create(PATH_API + PATH_QUERY)).with(csrf())
                 .contentType(APPLICATION_JSON)
@@ -242,7 +242,7 @@ public class QueryHandlerRestControllerIT {
 
         doReturn((long)quotaHardCreateAmount).when(queryHandlerService).getAmountOfQueriesByUserAndInterval(any(String.class), eq(quotaHardCreateIntervalMinutes));
         doReturn(Mono.just(1L)).when(queryHandlerService).runQuery(any(StructuredQuery.class), eq("test"));
-        doReturn(List.of()).when(termCodeValidation).getInvalidTermCodes(any(StructuredQuery.class));
+        doReturn(List.of()).when(termCodeValidation).getInvalidCriteria(any(StructuredQuery.class));
 
         var mvcResult = mockMvc.perform(post(URI.create(PATH_API + PATH_QUERY)).with(csrf())
                 .contentType(APPLICATION_JSON)
@@ -263,7 +263,7 @@ public class QueryHandlerRestControllerIT {
         doReturn((long)quotaHardCreateAmount).when(queryHandlerService).getAmountOfQueriesByUserAndInterval(any(String.class), eq(quotaHardCreateIntervalMinutes));
         doReturn((long)(quotaSoftCreateAmount - 1)).when(queryHandlerService).getAmountOfQueriesByUserAndInterval(any(String.class), eq(quotaSoftCreateIntervalMinutes));
         doReturn(Mono.just(1L)).when(queryHandlerService).runQuery(any(StructuredQuery.class), eq("test"));
-        doReturn(List.of()).when(termCodeValidation).getInvalidTermCodes(any(StructuredQuery.class));
+        doReturn(List.of()).when(termCodeValidation).getInvalidCriteria(any(StructuredQuery.class));
 
         var mvcResult = mockMvc.perform(post(URI.create(PATH_API + PATH_QUERY)).with(csrf())
                 .contentType(APPLICATION_JSON)
@@ -287,7 +287,7 @@ public class QueryHandlerRestControllerIT {
         mockMvc.perform(get(URI.create(PATH_API + PATH_QUERY)).with(csrf()).param("skipValidation", "false"))
                 .andExpect(status().isOk())
                 .andExpect(jsonPath("$[0].id").value(queryId))
-                .andExpect(jsonPath("$[0].invalidTerms").isNotEmpty());
+                .andExpect(jsonPath("$[0].invalidCriteria").isNotEmpty());
     }
 
     @Test
@@ -300,8 +300,8 @@ public class QueryHandlerRestControllerIT {
         mockMvc.perform(get(URI.create(PATH_API + PATH_QUERY)).with(csrf()).param("skipValidation", "true"))
             .andExpect(status().isOk())
             .andExpect(jsonPath("$[0].id").value(queryId))
-            .andExpect(jsonPath("$[0].invalidTerms").isArray())
-            .andExpect(jsonPath("$[0].invalidTerms").isEmpty());
+            .andExpect(jsonPath("$[0].invalidCriteria").isArray())
+            .andExpect(jsonPath("$[0].invalidCriteria").isEmpty());
     }
 
     @Test
@@ -314,7 +314,7 @@ public class QueryHandlerRestControllerIT {
         mockMvc.perform(get(URI.create(PATH_API + PATH_QUERY)).with(csrf()))
             .andExpect(status().isOk())
             .andExpect(jsonPath("$[0].id").value(queryId))
-            .andExpect(jsonPath("$[0].invalidTerms").isNotEmpty());
+            .andExpect(jsonPath("$[0].invalidCriteria").isNotEmpty());
     }
 
     @Test
@@ -348,7 +348,7 @@ public class QueryHandlerRestControllerIT {
         long queryId = 1;
         doReturn("test").when(queryHandlerService).getAuthorId(any(Long.class));
         doReturn(createValidApiQuery(queryId)).when(queryHandlerService).getQuery(any(Long.class));
-        doReturn(List.of()).when(termCodeValidation).getInvalidTermCodes(any(StructuredQuery.class));
+        doReturn(List.of()).when(termCodeValidation).getInvalidCriteria(any(StructuredQuery.class));
 
         mockMvc.perform(get(URI.create(PATH_API + PATH_QUERY + "/" + queryId)).with(csrf()))
                 .andExpect(status().isOk())
@@ -361,7 +361,7 @@ public class QueryHandlerRestControllerIT {
         long queryId = 1;
         doReturn("some-other-user").when(queryHandlerService).getAuthorId(any(Long.class));
         doReturn(createValidApiQuery(queryId)).when(queryHandlerService).getQuery(any(Long.class));
-        doReturn(List.of()).when(termCodeValidation).getInvalidTermCodes(any(StructuredQuery.class));
+        doReturn(List.of()).when(termCodeValidation).getInvalidCriteria(any(StructuredQuery.class));
 
         mockMvc.perform(get(URI.create(PATH_API + PATH_QUERY + "/" + queryId)).with(csrf()))
                 .andExpect(status().isForbidden());
@@ -694,7 +694,7 @@ public class QueryHandlerRestControllerIT {
                 .id(id)
                 .label("abc")
                 .createdAt(new Timestamp(new java.util.Date().getTime()))
-                .invalidTerms(skipValidation ? List.of() : List.of(createTermCode()))
+                .invalidCriteria(skipValidation ? List.of() : List.of(createInvalidCriterion()))
                 .build();
     }
 
@@ -722,7 +722,7 @@ public class QueryHandlerRestControllerIT {
                 .content(createValidStructuredQuery())
                 .label("test")
                 .comment("test")
-                .invalidTerms(List.of())
+                .invalidCriteria(List.of())
                 .build();
     }
 

--- a/src/test/java/de/numcodex/feasibility_gui_backend/query/v3/QueryHandlerRestControllerIT.java
+++ b/src/test/java/de/numcodex/feasibility_gui_backend/query/v3/QueryHandlerRestControllerIT.java
@@ -184,7 +184,7 @@ public class QueryHandlerRestControllerIT {
 
     @Test
     @WithMockUser(roles = "FEASIBILITY_TEST_USER", username = "test")
-    public void testValidate2QueryEndpoint_SucceedsOnValidQuery() throws Exception {
+    public void testValidateQueryEndpoint_SucceedsOnValidQuery() throws Exception {
         StructuredQuery testQuery = createValidStructuredQuery();
 
         doReturn(List.of()).when(termCodeValidation).getInvalidTermCodes(any(StructuredQuery.class));
@@ -193,27 +193,23 @@ public class QueryHandlerRestControllerIT {
                 .contentType(APPLICATION_JSON)
                 .content(jsonUtil.writeValueAsString(testQuery)))
             .andExpect(status().isOk())
-            .andExpect(jsonPath("$.invalidTerms").isEmpty());
+            .andExpect(jsonPath("$.invalidCriteria").isEmpty());
     }
 
     @Test
     @WithMockUser(roles = "FEASIBILITY_TEST_USER")
-    public void testValidate2QueryEndpoint_SucceedsDespiteInvalidTermcodesWith200() throws Exception {
+    public void testValidateQueryEndpoint_SucceedsDespiteInvalidTermcodesWith200() throws Exception {
         StructuredQuery testQuery = createValidStructuredQuery();
-        var invalidTermCode = TermCode.builder()
-            .code("LL2191-6")
-            .system("http://loinc.org")
-            .display("Geschlecht")
-            .build();
+        var invalidCriterion = createInvalidCriterion();
 
-        doReturn(List.of(invalidTermCode)).when(termCodeValidation).getInvalidTermCodes(any(StructuredQuery.class));
+        doReturn(List.of(invalidCriterion)).when(termCodeValidation).getInvalidCriteria(any(StructuredQuery.class));
 
         mockMvc.perform(post(URI.create(PATH_API + PATH_QUERY + "/validate")).with(csrf())
                 .contentType(APPLICATION_JSON)
                 .content(jsonUtil.writeValueAsString(testQuery)))
             .andExpect(status().isOk())
-            .andExpect(jsonPath("$.invalidTerms").exists())
-            .andExpect(jsonPath("$.invalidTerms").isNotEmpty());
+            .andExpect(jsonPath("$.invalidCriteria").exists())
+            .andExpect(jsonPath("$.invalidCriteria").isNotEmpty());
     }
 
     @Test
@@ -708,6 +704,14 @@ public class QueryHandlerRestControllerIT {
             .code("LL2191-6")
             .system("http://loinc.org")
             .display("Geschlecht")
+            .build();
+    }
+
+    @NotNull
+    private static Criterion createInvalidCriterion() {
+        return Criterion.builder()
+            .termCodes(List.of(createTermCode()))
+            .context(null)
             .build();
     }
 

--- a/src/test/java/de/numcodex/feasibility_gui_backend/query/v3/QueryTemplateHandlerRestControllerIT.java
+++ b/src/test/java/de/numcodex/feasibility_gui_backend/query/v3/QueryTemplateHandlerRestControllerIT.java
@@ -121,7 +121,7 @@ public class QueryTemplateHandlerRestControllerIT {
 
         doReturn(createValidPersistenceQueryTemplateToGet(queryTemplateId)).when(queryHandlerService).getQueryTemplate(any(Long.class), any(String.class));
         doReturn(createValidApiQueryTemplateToGet(queryTemplateId)).when(queryHandlerService).convertTemplatePersistenceToApi(any(de.numcodex.feasibility_gui_backend.query.persistence.QueryTemplate.class));
-        doReturn(List.of()).when(termCodeValidation).getInvalidTermCodes(any(StructuredQuery.class));
+        doReturn(List.of()).when(termCodeValidation).getInvalidCriteria(any(StructuredQuery.class));
 
         mockMvc.perform(get(URI.create(PATH_API + PATH_QUERY + PATH_TEMPLATE + "/" + queryTemplateId)).with(csrf()))
                 .andExpect(status().isOk())
@@ -135,7 +135,7 @@ public class QueryTemplateHandlerRestControllerIT {
 
         doThrow(QueryTemplateException.class).when(queryHandlerService).getQueryTemplate(any(Long.class), any(String.class));
         doReturn(createValidApiQueryTemplateToGet(queryTemplateId)).when(queryHandlerService).convertTemplatePersistenceToApi(any(de.numcodex.feasibility_gui_backend.query.persistence.QueryTemplate.class));
-        doReturn(List.of()).when(termCodeValidation).getInvalidTermCodes(any(StructuredQuery.class));
+        doReturn(List.of()).when(termCodeValidation).getInvalidCriteria(any(StructuredQuery.class));
 
         mockMvc.perform(get(URI.create(PATH_API + PATH_QUERY + PATH_TEMPLATE + "/" + queryTemplateId)).with(csrf()))
                 .andExpect(status().isNotFound());
@@ -148,7 +148,7 @@ public class QueryTemplateHandlerRestControllerIT {
 
         doReturn(createValidPersistenceQueryTemplateToGet(queryTemplateId)).when(queryHandlerService).getQueryTemplate(any(Long.class), any(String.class));
         doThrow(JsonProcessingException.class).when(queryHandlerService).convertTemplatePersistenceToApi(any(de.numcodex.feasibility_gui_backend.query.persistence.QueryTemplate.class));
-        doReturn(List.of()).when(termCodeValidation).getInvalidTermCodes(any(StructuredQuery.class));
+        doReturn(List.of()).when(termCodeValidation).getInvalidCriteria(any(StructuredQuery.class));
 
         mockMvc.perform(get(URI.create(PATH_API + PATH_QUERY + PATH_TEMPLATE + "/" + queryTemplateId)).with(csrf()))
                 .andExpect(status().isInternalServerError());
@@ -184,7 +184,7 @@ public class QueryTemplateHandlerRestControllerIT {
         int listSize = 5;
         doReturn(createValidPersistenceQueryTemplateListToGet(listSize)).when(queryHandlerService).getQueryTemplatesForAuthor(any(String.class));
         doReturn(createValidApiQueryTemplateToGet(ThreadLocalRandom.current().nextInt())).when(queryHandlerService).convertTemplatePersistenceToApi(any(de.numcodex.feasibility_gui_backend.query.persistence.QueryTemplate.class));
-        doReturn(List.of()).when(termCodeValidation).getInvalidTermCodes(any(StructuredQuery.class));
+        doReturn(List.of()).when(termCodeValidation).getInvalidCriteria(any(StructuredQuery.class));
 
         mockMvc.perform(get(URI.create(PATH_API + PATH_QUERY + PATH_TEMPLATE)).with(csrf()))
             .andExpect(status().isOk())
@@ -199,7 +199,7 @@ public class QueryTemplateHandlerRestControllerIT {
         int listSize = 5;
         doReturn(createValidPersistenceQueryTemplateListToGet(listSize)).when(queryHandlerService).getQueryTemplatesForAuthor(any(String.class));
         doReturn(createValidApiQueryTemplateToGet(ThreadLocalRandom.current().nextInt())).when(queryHandlerService).convertTemplatePersistenceToApi(any(de.numcodex.feasibility_gui_backend.query.persistence.QueryTemplate.class));
-        doReturn(List.of(createTermCode())).when(termCodeValidation).getInvalidTermCodes(any(StructuredQuery.class));
+        doReturn(List.of(createInvalidCriterion())).when(termCodeValidation).getInvalidCriteria(any(StructuredQuery.class));
 
         mockMvc.perform(get(URI.create(PATH_API + PATH_QUERY + PATH_TEMPLATE)).with(csrf()))
             .andExpect(status().isOk())
@@ -212,7 +212,7 @@ public class QueryTemplateHandlerRestControllerIT {
         int listSize = 5;
         doReturn(createValidPersistenceQueryTemplateListToGet(listSize)).when(queryHandlerService).getQueryTemplatesForAuthor(any(String.class));
         doThrow(JsonProcessingException.class).when(queryHandlerService).convertTemplatePersistenceToApi(any(de.numcodex.feasibility_gui_backend.query.persistence.QueryTemplate.class));
-        doReturn(List.of(createTermCode())).when(termCodeValidation).getInvalidTermCodes(any(StructuredQuery.class));
+        doReturn(List.of(createInvalidCriterion())).when(termCodeValidation).getInvalidCriteria(any(StructuredQuery.class));
 
         mockMvc.perform(get(URI.create(PATH_API + PATH_QUERY + PATH_TEMPLATE)).with(csrf()))
             .andExpect(status().isOk())
@@ -275,7 +275,7 @@ public class QueryTemplateHandlerRestControllerIT {
                 .content(createValidStructuredQuery())
                 .label("TestLabel")
                 .comment("TestComment")
-                .invalidTerms(List.of())
+                .invalidCriteria(List.of())
                 .isValid(true)
                 .build();
     }
@@ -309,7 +309,7 @@ public class QueryTemplateHandlerRestControllerIT {
                 .comment("TestComment")
                 .lastModified(new Timestamp(new java.util.Date().getTime()).toString())
                 .createdBy("someone")
-                .invalidTerms(List.of())
+                .invalidCriteria(List.of())
                 .isValid(true)
                 .build();
     }
@@ -335,5 +335,13 @@ public class QueryTemplateHandlerRestControllerIT {
                 .system("http://loinc.org")
                 .display("Geschlecht")
                 .build();
+    }
+
+    @NotNull
+    private static Criterion createInvalidCriterion() {
+        return Criterion.builder()
+            .context(null)
+            .termCodes(List.of(createTermCode()))
+            .build();
     }
 }

--- a/src/test/java/de/numcodex/feasibility_gui_backend/terminology/validation/TermCodeValidationTest.java
+++ b/src/test/java/de/numcodex/feasibility_gui_backend/terminology/validation/TermCodeValidationTest.java
@@ -36,34 +36,41 @@ class TermCodeValidationTest {
 
     @ParameterizedTest
     @ValueSource(strings = {"true", "false"})
-    void getInvalidTermCodes_emptyOnValidTermcodes(boolean withExclusionCriteria) {
+    void getInvalidCriteria_emptyOnValidCriteria(boolean withExclusionCriteria) {
         doReturn(true).when(terminologyService).isExistingTermCode(any(String.class), any(String.class), isNull());
 
-        var invalidTermCodes = termCodeValidation.getInvalidTermCodes(createValidStructuredQuery(withExclusionCriteria));
+        var invalidCriteria = termCodeValidation.getInvalidCriteria(createValidStructuredQuery(withExclusionCriteria));
 
-        assertTrue(invalidTermCodes.isEmpty());
+        assertTrue(invalidCriteria.isEmpty());
     }
 
     @ParameterizedTest
     @ValueSource(strings = {"true", "false"})
-    void getInvalidTermCodes_notEmptyOnInvalidTermcode(boolean withExclusionCriteria) {
+    void getInvalidCriteria_notEmptyOnInvalidTermcode(boolean withExclusionCriteria) {
         doReturn(false).when(terminologyService).isExistingTermCode(any(String.class), any(String.class), isNull());
 
-        var invalidTermCodes = termCodeValidation.getInvalidTermCodes(createValidStructuredQuery(withExclusionCriteria));
+        var invalidCriteria = termCodeValidation.getInvalidCriteria(createValidStructuredQuery(withExclusionCriteria));
 
-        assertFalse(invalidTermCodes.isEmpty());
-        assertEquals(withExclusionCriteria ? 2 : 1, invalidTermCodes.size());
+        assertFalse(invalidCriteria.isEmpty());
+        assertEquals(withExclusionCriteria ? 2 : 1, invalidCriteria.size());
     }
 
     @NotNull
     private static StructuredQuery createValidStructuredQuery(boolean withExclusionCriteria) {
+        var context = TermCode.builder()
+            .code("Laboruntersuchung")
+            .system("fdpg.mii.cds")
+            .display("Laboruntersuchung")
+            .version("1.0.0")
+            .build();
         var termCode = TermCode.builder()
-                .code("LL2191-6")
+                .code("19113-0")
                 .system("http://loinc.org")
-                .display("Geschlecht")
+                .display("IgE")
                 .build();
         var criterion = Criterion.builder()
                 .termCodes(List.of(termCode))
+                .context(context)
                 .attributeFilters(List.of())
                 .build();
         return StructuredQuery.builder()


### PR DESCRIPTION
- Return invalid criteria (termcode/context) instead of just termcode
- Replace old /validate endpoint with the new one
- add swagger documentation for the endpoint
- When no invalid terms are found, return an empty array instead of omitting the parameter
- Don't include the invalid terms list in the structured query itself but create a new object ValidatedStructuredQuery, containing the original query and the list of invalid terms
- Add a new endpoint that takes a structured query and sends back the same query with additional invalidTerms if present