### PR TITLE
#282 - Update Spring Boot

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>org.springframework.boot</groupId>
     <artifactId>spring-boot-starter-parent</artifactId>
-    <version>3.2.4</version>
+    <version>3.2.5</version>
     <relativePath /> <!-- lookup parent from repository -->
   </parent>
 
@@ -61,22 +61,9 @@
       <artifactId>spring-boot-starter-data-jpa</artifactId>
     </dependency>
 
-    <!-- Fix CVE-2024-29025. Remove exclusion and manual inclusion when update is included in spring-boot-starter-webflux -->
     <dependency>
       <groupId>org.springframework.boot</groupId>
       <artifactId>spring-boot-starter-webflux</artifactId>
-      <exclusions>
-        <exclusion>
-          <groupId>io.netty</groupId>
-          <artifactId>netty-codec-http</artifactId>
-        </exclusion>
-      </exclusions>
-    </dependency>
-
-    <dependency>
-      <groupId>io.netty</groupId>
-      <artifactId>netty-codec-http</artifactId>
-      <version>4.1.108.Final</version>
     </dependency>
 
     <dependency>
@@ -291,14 +278,6 @@
       <groupId>org.springframework.security</groupId>
       <artifactId>spring-security-test</artifactId>
       <scope>test</scope>
-    </dependency>
-
-    <!-- This dependency is only added to address a vulnerability in  org.springframework.boot-->
-    <!-- Remove this once the vulnerability is adressed in the next version -->
-    <dependency>
-      <groupId>org.yaml</groupId>
-      <artifactId>snakeyaml</artifactId>
-      <version>2.0</version>
     </dependency>
 
     <dependency>


### PR DESCRIPTION
- update spring boot to 3.2.5
- remove manual netty-codec-http dependency inclusion since the vulnerable version is addressed in the spring boot update
- remove manual snakeyaml depdendency inclusion since it was also updated in spring boot in the meantime