### PR TITLE
#292 - OPS are not exhaustively searchable

### DIFF
--- a/src/main/java/de/numcodex/feasibility_gui_backend/terminology/TerminologyService.java
+++ b/src/main/java/de/numcodex/feasibility_gui_backend/terminology/TerminologyService.java
@@ -195,8 +195,8 @@ public class TerminologyService {
     return terminologyEntry.getDisplay().toLowerCase().startsWith(query.toLowerCase()) ||
         Arrays.stream(terminologyEntry.getDisplay().toLowerCase().split(" "))
             .anyMatch(var -> var.startsWith(query.toLowerCase())) ||
-        (terminologyEntry.getTermCodes().stream().anyMatch(termCode -> termCode.code()
-            .startsWith(query)));
+        (terminologyEntry.getTermCodes().stream().anyMatch(termCode -> termCode.code().toLowerCase()
+            .startsWith(query.toLowerCase())));
   }
 
   public List<String> getIntersection(String criteriaSetUrl, List<String> contextTermCodeHashList) {


### PR DESCRIPTION
- add missing lowercase conversion in TerminologyService.matchesQuery