### PR TITLE
#294 - Update sq2cql to version v0.3.0

### DIFF
--- a/.github/integration-test/docker-compose.yml
+++ b/.github/integration-test/docker-compose.yml
@@ -79,7 +79,7 @@ services:
       POSTGRES_DB: "codex_ui"
 
   blaze:
-    image: "samply/blaze:0.22"
+    image: "samply/blaze:0.27"
     environment:
       BASE_URL: "http://blaze:8080"
       JAVA_TOOL_OPTIONS: "-Xmx1g"
@@ -90,7 +90,7 @@ services:
       - "blaze-data:/app/data"
 
   flare:
-    image: ghcr.io/medizininformatik-initiative/flare:2.1.1
+    image: ghcr.io/medizininformatik-initiative/flare:2.2.0
     ports:
       - "8092:8080"
     environment:

--- a/.github/scripts/post-test-query.sh
+++ b/.github/scripts/post-test-query.sh
@@ -14,38 +14,38 @@ response=$(curl -s -i \
   --header "Authorization: Bearer $access_token" \
   --header 'Content-Type: application/json' \
   --data '{
-            "version": "http://to_be_decided.com/draft-1/schema#",
-            "inclusionCriteria": [
-              [
-                {
-                  "attributeFilters": [],
-                  "termCodes": [
-                    {
-                      "code": "263495000",
-                      "display": "Geschlecht",
-                      "system": "http://snomed.info/sct"
-                    }
-                  ],
-                  "context": {
-                    "code": "Patient",
-                    "display": "Patient",
-                    "system": "fdpg.mii.cds",
-                    "version": "1.0.0"
-                  },
-                  "valueFilter": {
-                    "selectedConcepts": [
-                      {
-                        "code": "male",
-                        "display": "Male",
-                        "system": "http://hl7.org/fhir/administrative-gender"
-                      }
-                    ],
-                    "type": "concept"
-                  }
-                }
-              ]
-            ]
+    "version": "http://to_be_decided.com/draft-1/schema#",
+    "inclusionCriteria": [
+      [
+        {
+          "attributeFilters": [],
+          "termCodes": [
+            {
+              "code": "263495000",
+              "display": "Geschlecht",
+              "system": "http://snomed.info/sct"
+            }
+          ],
+          "context": {
+            "code": "Patient",
+            "display": "Patient",
+            "system": "fdpg.mii.cds",
+            "version": "1.0.0"
+          },
+          "valueFilter": {
+            "selectedConcepts": [
+              {
+                "code": "male",
+                "display": "Male",
+                "system": "http://hl7.org/fhir/administrative-gender"
+              }
+            ],
+            "type": "concept"
           }
+        }
+      ]
+    ]
+  }
 ')
 
 result_location=$(echo "$response" | grep -i location | awk '{print $2}')

--- a/pom.xml
+++ b/pom.xml
@@ -224,7 +224,7 @@
     <dependency>
       <groupId>de.medizininformatik-initiative</groupId>
       <artifactId>sq2cql</artifactId>
-      <version>0.2.16</version>
+      <version>0.3.0-rc.1</version>
     </dependency>
 
     <dependency>

--- a/src/test/java/de/numcodex/feasibility_gui_backend/query/broker/direct/DirectBrokerClientCqlIT.java
+++ b/src/test/java/de/numcodex/feasibility_gui_backend/query/broker/direct/DirectBrokerClientCqlIT.java
@@ -42,7 +42,7 @@ class DirectBrokerClientCqlIT {
     private static final Long TEST_BACKEND_QUERY_ID = 1L;
 
     private final GenericContainer<?> blaze = new GenericContainer<>(
-        DockerImageName.parse("samply/blaze:0.25"))
+        DockerImageName.parse("samply/blaze:0.27"))
         .withImagePullPolicy(PullPolicy.alwaysPull())
         .withExposedPorts(8080)
         .waitingFor(Wait.forHttp("/health").forStatusCodeMatching(c -> c >= 200 && c <= 500))

--- a/src/test/java/de/numcodex/feasibility_gui_backend/query/broker/dsf/DSFFhirWebClientProviderTest.java
+++ b/src/test/java/de/numcodex/feasibility_gui_backend/query/broker/dsf/DSFFhirWebClientProviderTest.java
@@ -19,7 +19,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 public class DSFFhirWebClientProviderTest {
 
     @Container
-    private GenericContainer<?> blaze = new GenericContainer<>("samply/blaze:0.25")
+    private GenericContainer<?> blaze = new GenericContainer<>("samply/blaze:0.27")
             .withExposedPorts(8080)
             .withNetwork(Network.newNetwork())
             .withReuse(true);


### PR DESCRIPTION
* Update sq2cql to (currently) 0.3.0-rc.1 - update when final release is available!
* Update blaze, flare and keycloak in tests