### PR TITLE
#327 - Update Undertow

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -46,33 +46,20 @@
       <groupId>org.springframework.boot</groupId>
       <artifactId>spring-boot-starter-undertow</artifactId>
     </dependency>
-
-<!--    Remove those when they are updated in the undertow dependency-->
-    <dependency>
-      <groupId>org.jboss.xnio</groupId>
-      <artifactId>xnio-api</artifactId>
-      <version>3.8.14.Final</version>
-    </dependency>
-    <dependency>
-      <groupId>org.jboss.xnio</groupId>
-      <artifactId>xnio-nio</artifactId>
-      <version>3.8.14.Final</version>
-      <scope>runtime</scope>
-    </dependency>
     <dependency>
       <groupId>io.undertow</groupId>
       <artifactId>undertow-core</artifactId>
-      <version>2.3.14.Final</version>
+      <version>2.3.15.Final</version>
     </dependency>
     <dependency>
       <groupId>io.undertow</groupId>
       <artifactId>undertow-servlet</artifactId>
-      <version>2.3.14.Final</version>
+      <version>2.3.15.Final</version>
     </dependency>
     <dependency>
       <groupId>io.undertow</groupId>
       <artifactId>undertow-websockets-jsr</artifactId>
-      <version>2.3.14.Final</version>
+      <version>2.3.15.Final</version>
     </dependency>
 
     <dependency>


### PR DESCRIPTION
- update undertow to 2.3.15.Final
- remove override of xnio dependencies since the new undertow version includes even newer ones