### PR TITLE
#330 - Empty filter lists lead to missing results

### DIFF
--- a/src/main/java/de/numcodex/feasibility_gui_backend/terminology/es/CodeableConceptService.java
+++ b/src/main/java/de/numcodex/feasibility_gui_backend/terminology/es/CodeableConceptService.java
@@ -17,6 +17,7 @@ import org.springframework.data.elasticsearch.core.SearchHits;
 import org.springframework.data.util.Pair;
 import org.springframework.lang.Nullable;
 import org.springframework.stereotype.Service;
+import org.springframework.util.CollectionUtils;
 
 import java.util.ArrayList;
 import java.util.List;
@@ -41,7 +42,7 @@ public class CodeableConceptService {
                                                                @Nullable int page) {
 
     List<Pair<String, List<String>>> filterList = new ArrayList<>();
-    if (valueSets != null && !valueSets.isEmpty()) {
+    if (!CollectionUtils.isEmpty(valueSets)) {
       filterList.add(Pair.of("value_sets", valueSets));
     }
 

--- a/src/main/java/de/numcodex/feasibility_gui_backend/terminology/es/TerminologyEsService.java
+++ b/src/main/java/de/numcodex/feasibility_gui_backend/terminology/es/TerminologyEsService.java
@@ -24,6 +24,7 @@ import org.springframework.data.elasticsearch.core.SearchHits;
 import org.springframework.data.util.Pair;
 import org.springframework.lang.Nullable;
 import org.springframework.stereotype.Service;
+import org.springframework.util.CollectionUtils;
 
 import java.util.*;
 
@@ -81,16 +82,16 @@ public class TerminologyEsService {
 
 
     List<Pair<String, List<String>>> filterList = new ArrayList<>();
-    if (criteriaSets != null) {
+    if (!CollectionUtils.isEmpty(criteriaSets)) {
       filterList.add(Pair.of("criteria_sets", criteriaSets));
     }
-    if (context != null) {
+    if (!CollectionUtils.isEmpty(context)) {
       filterList.add(Pair.of("context.code", context));
     }
-    if (kdsModule != null) {
+    if (!CollectionUtils.isEmpty(kdsModule)) {
       filterList.add(Pair.of("kds_module", kdsModule));
     }
-    if (terminology != null) {
+    if (!CollectionUtils.isEmpty(terminology)) {
       filterList.add(Pair.of("terminology", terminology));
     }
 


### PR DESCRIPTION
Please check if this solves the issue of no found results when an empty parameter for contexts, terminologies, kds-modules or criteria-sets is submitted