### PR TITLE
#332 - Remove @Data annotation from jpa classes

### DIFF
--- a/src/main/java/de/numcodex/feasibility_gui_backend/dse/persistence/DseProfile.java
+++ b/src/main/java/de/numcodex/feasibility_gui_backend/dse/persistence/DseProfile.java
@@ -1,24 +1,43 @@
 package de.numcodex.feasibility_gui_backend.dse.persistence;
 
 import jakarta.persistence.*;
-import lombok.Data;
-import lombok.EqualsAndHashCode;
+import lombok.*;
+import org.hibernate.proxy.HibernateProxy;
 
 import java.io.Serializable;
+import java.util.Objects;
 
 @Entity
 @Table(name = "dse_profile", schema = "public")
-@Data
-@EqualsAndHashCode
+@Getter
+@Setter
+@ToString
+@RequiredArgsConstructor
 public class DseProfile implements Serializable {
   @GeneratedValue(strategy = GenerationType.IDENTITY)
   @Id
   @Column(name = "id", nullable = false)
-  private int id;
+  private Long id;
   @Basic
   @Column(name = "url", nullable = false, length = -1)
   private String url;
   @Basic
   @Column(name = "entry", columnDefinition = "json", nullable = false)
   private String entry;
+
+  @Override
+  public final boolean equals(Object o) {
+    if (this == o) return true;
+    if (o == null) return false;
+    Class<?> oEffectiveClass = o instanceof HibernateProxy ? ((HibernateProxy) o).getHibernateLazyInitializer().getPersistentClass() : o.getClass();
+    Class<?> thisEffectiveClass = this instanceof HibernateProxy ? ((HibernateProxy) this).getHibernateLazyInitializer().getPersistentClass() : this.getClass();
+    if (thisEffectiveClass != oEffectiveClass) return false;
+    DseProfile that = (DseProfile) o;
+    return getId() != null && Objects.equals(getId(), that.getId());
+  }
+
+  @Override
+  public final int hashCode() {
+    return this instanceof HibernateProxy ? ((HibernateProxy) this).getHibernateLazyInitializer().getPersistentClass().hashCode() : getClass().hashCode();
+  }
 }

--- a/src/main/java/de/numcodex/feasibility_gui_backend/query/persistence/Query.java
+++ b/src/main/java/de/numcodex/feasibility_gui_backend/query/persistence/Query.java
@@ -1,19 +1,16 @@
 package de.numcodex.feasibility_gui_backend.query.persistence;
 
-import jakarta.persistence.CascadeType;
-import jakarta.persistence.Column;
-import jakarta.persistence.Entity;
-import jakarta.persistence.FetchType;
-import jakarta.persistence.GeneratedValue;
-import jakarta.persistence.GenerationType;
-import jakarta.persistence.Id;
-import jakarta.persistence.JoinColumn;
-import jakarta.persistence.ManyToOne;
-import jakarta.persistence.OneToOne;
-import java.sql.Timestamp;
-import lombok.Data;
+import jakarta.persistence.*;
+import lombok.*;
+import org.hibernate.proxy.HibernateProxy;
 
-@Data
+import java.sql.Timestamp;
+import java.util.Objects;
+
+@Getter
+@Setter
+@ToString
+@RequiredArgsConstructor
 @Entity
 public class Query {
 
@@ -29,8 +26,25 @@ public class Query {
 
     @ManyToOne(fetch = FetchType.LAZY, cascade = CascadeType.ALL)
     @JoinColumn(referencedColumnName = "id", name = "query_content_id")
+    @ToString.Exclude
     private QueryContent queryContent;
 
     @OneToOne(mappedBy = "query", cascade = CascadeType.ALL)
     private SavedQuery savedQuery;
+
+    @Override
+    public final boolean equals(Object o) {
+        if (this == o) return true;
+        if (o == null) return false;
+        Class<?> oEffectiveClass = o instanceof HibernateProxy ? ((HibernateProxy) o).getHibernateLazyInitializer().getPersistentClass() : o.getClass();
+        Class<?> thisEffectiveClass = this instanceof HibernateProxy ? ((HibernateProxy) this).getHibernateLazyInitializer().getPersistentClass() : this.getClass();
+        if (thisEffectiveClass != oEffectiveClass) return false;
+        Query query = (Query) o;
+        return getId() != null && Objects.equals(getId(), query.getId());
+    }
+
+    @Override
+    public final int hashCode() {
+        return this instanceof HibernateProxy ? ((HibernateProxy) this).getHibernateLazyInitializer().getPersistentClass().hashCode() : getClass().hashCode();
+    }
 }

--- a/src/main/java/de/numcodex/feasibility_gui_backend/query/persistence/QueryContent.java
+++ b/src/main/java/de/numcodex/feasibility_gui_backend/query/persistence/QueryContent.java
@@ -1,16 +1,16 @@
 package de.numcodex.feasibility_gui_backend.query.persistence;
 
-import jakarta.persistence.Column;
-import jakarta.persistence.Entity;
-import jakarta.persistence.GeneratedValue;
-import jakarta.persistence.GenerationType;
-import jakarta.persistence.Id;
-import lombok.Data;
-import lombok.NoArgsConstructor;
+import jakarta.persistence.*;
+import lombok.*;
+import org.hibernate.proxy.HibernateProxy;
 
-@Data
-@Entity
+import java.util.Objects;
+
+@Getter
+@Setter
+@ToString
 @NoArgsConstructor
+@Entity
 public class QueryContent {
 
     @Id
@@ -25,5 +25,21 @@ public class QueryContent {
 
     public QueryContent(String queryContent) {
         this.queryContent = queryContent;
+    }
+
+    @Override
+    public final boolean equals(Object o) {
+        if (this == o) return true;
+        if (o == null) return false;
+        Class<?> oEffectiveClass = o instanceof HibernateProxy ? ((HibernateProxy) o).getHibernateLazyInitializer().getPersistentClass() : o.getClass();
+        Class<?> thisEffectiveClass = this instanceof HibernateProxy ? ((HibernateProxy) this).getHibernateLazyInitializer().getPersistentClass() : this.getClass();
+        if (thisEffectiveClass != oEffectiveClass) return false;
+        QueryContent that = (QueryContent) o;
+        return getId() != null && Objects.equals(getId(), that.getId());
+    }
+
+    @Override
+    public final int hashCode() {
+        return this instanceof HibernateProxy ? ((HibernateProxy) this).getHibernateLazyInitializer().getPersistentClass().hashCode() : getClass().hashCode();
     }
 }

--- a/src/main/java/de/numcodex/feasibility_gui_backend/query/persistence/QueryDispatch.java
+++ b/src/main/java/de/numcodex/feasibility_gui_backend/query/persistence/QueryDispatch.java
@@ -1,20 +1,19 @@
 package de.numcodex.feasibility_gui_backend.query.persistence;
 
-import static jakarta.persistence.FetchType.LAZY;
+import jakarta.persistence.*;
+import lombok.*;
+import org.hibernate.proxy.HibernateProxy;
 
-import jakarta.persistence.Column;
-import jakarta.persistence.Convert;
-import jakarta.persistence.Embeddable;
-import jakarta.persistence.EmbeddedId;
-import jakarta.persistence.Entity;
-import jakarta.persistence.JoinColumn;
-import jakarta.persistence.ManyToOne;
-import jakarta.persistence.MapsId;
 import java.io.Serializable;
 import java.sql.Timestamp;
-import lombok.Data;
+import java.util.Objects;
 
-@Data
+import static jakarta.persistence.FetchType.LAZY;
+
+@Getter
+@Setter
+@ToString
+@RequiredArgsConstructor
 @Entity
 public class QueryDispatch {
 
@@ -24,6 +23,7 @@ public class QueryDispatch {
     @MapsId("queryId")
     @JoinColumn(referencedColumnName = "id", name = "query_id", nullable = false)
     @ManyToOne(fetch = LAZY)
+    @ToString.Exclude
     private Query query;
 
     @Column(name = "dispatched_at", insertable = false, updatable = false)
@@ -41,5 +41,21 @@ public class QueryDispatch {
         @Convert(converter = BrokerTypeConverter.class)
         @Column(name = "broker_type")
         private BrokerClientType brokerType;
+    }
+
+    @Override
+    public final boolean equals(Object o) {
+        if (this == o) return true;
+        if (o == null) return false;
+        Class<?> oEffectiveClass = o instanceof HibernateProxy ? ((HibernateProxy) o).getHibernateLazyInitializer().getPersistentClass() : o.getClass();
+        Class<?> thisEffectiveClass = this instanceof HibernateProxy ? ((HibernateProxy) this).getHibernateLazyInitializer().getPersistentClass() : this.getClass();
+        if (thisEffectiveClass != oEffectiveClass) return false;
+        QueryDispatch that = (QueryDispatch) o;
+        return getId() != null && Objects.equals(getId(), that.getId());
+    }
+
+    @Override
+    public final int hashCode() {
+        return Objects.hash(id);
     }
 }

--- a/src/main/java/de/numcodex/feasibility_gui_backend/query/persistence/QueryTemplate.java
+++ b/src/main/java/de/numcodex/feasibility_gui_backend/query/persistence/QueryTemplate.java
@@ -1,17 +1,16 @@
 package de.numcodex.feasibility_gui_backend.query.persistence;
 
-import java.sql.Timestamp;
-import jakarta.persistence.Column;
-import jakarta.persistence.Entity;
-import jakarta.persistence.FetchType;
-import jakarta.persistence.GeneratedValue;
-import jakarta.persistence.GenerationType;
-import jakarta.persistence.Id;
-import jakarta.persistence.JoinColumn;
-import jakarta.persistence.ManyToOne;
-import lombok.Data;
+import jakarta.persistence.*;
+import lombok.*;
+import org.hibernate.proxy.HibernateProxy;
 
-@Data
+import java.sql.Timestamp;
+import java.util.Objects;
+
+@Getter
+@Setter
+@ToString
+@RequiredArgsConstructor
 @Entity
 public class QueryTemplate {
 
@@ -21,6 +20,7 @@ public class QueryTemplate {
 
     @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(referencedColumnName = "id", name = "query_id")
+    @ToString.Exclude
     private Query query;
 
     @Column(name = "label", nullable = false)
@@ -31,4 +31,20 @@ public class QueryTemplate {
 
     @Column(name = "last_modified", insertable = false)
     private Timestamp lastModified;
+
+    @Override
+    public final boolean equals(Object o) {
+        if (this == o) return true;
+        if (o == null) return false;
+        Class<?> oEffectiveClass = o instanceof HibernateProxy ? ((HibernateProxy) o).getHibernateLazyInitializer().getPersistentClass() : o.getClass();
+        Class<?> thisEffectiveClass = this instanceof HibernateProxy ? ((HibernateProxy) this).getHibernateLazyInitializer().getPersistentClass() : this.getClass();
+        if (thisEffectiveClass != oEffectiveClass) return false;
+        QueryTemplate that = (QueryTemplate) o;
+        return getId() != null && Objects.equals(getId(), that.getId());
+    }
+
+    @Override
+    public final int hashCode() {
+        return this instanceof HibernateProxy ? ((HibernateProxy) this).getHibernateLazyInitializer().getPersistentClass().hashCode() : getClass().hashCode();
+    }
 }

--- a/src/main/java/de/numcodex/feasibility_gui_backend/query/persistence/SavedQuery.java
+++ b/src/main/java/de/numcodex/feasibility_gui_backend/query/persistence/SavedQuery.java
@@ -1,16 +1,15 @@
 package de.numcodex.feasibility_gui_backend.query.persistence;
 
-import jakarta.persistence.Column;
-import jakarta.persistence.Entity;
-import jakarta.persistence.FetchType;
-import jakarta.persistence.GeneratedValue;
-import jakarta.persistence.GenerationType;
-import jakarta.persistence.Id;
-import jakarta.persistence.JoinColumn;
-import jakarta.persistence.OneToOne;
-import lombok.Data;
+import jakarta.persistence.*;
+import lombok.*;
+import org.hibernate.proxy.HibernateProxy;
 
-@Data
+import java.util.Objects;
+
+@Getter
+@Setter
+@ToString
+@RequiredArgsConstructor
 @Entity
 public class SavedQuery {
 
@@ -20,6 +19,7 @@ public class SavedQuery {
 
   @JoinColumn(referencedColumnName = "id", name = "query_id", nullable = false)
   @OneToOne(fetch = FetchType.LAZY)
+  @ToString.Exclude
   private Query query;
 
   @Column(name = "label", nullable = false)
@@ -30,4 +30,20 @@ public class SavedQuery {
 
   @Column(name = "result_size")
   private Long resultSize;
+
+  @Override
+  public final boolean equals(Object o) {
+    if (this == o) return true;
+    if (o == null) return false;
+    Class<?> oEffectiveClass = o instanceof HibernateProxy ? ((HibernateProxy) o).getHibernateLazyInitializer().getPersistentClass() : o.getClass();
+    Class<?> thisEffectiveClass = this instanceof HibernateProxy ? ((HibernateProxy) this).getHibernateLazyInitializer().getPersistentClass() : this.getClass();
+    if (thisEffectiveClass != oEffectiveClass) return false;
+    SavedQuery that = (SavedQuery) o;
+    return getId() != null && Objects.equals(getId(), that.getId());
+  }
+
+  @Override
+  public final int hashCode() {
+    return this instanceof HibernateProxy ? ((HibernateProxy) this).getHibernateLazyInitializer().getPersistentClass().hashCode() : getClass().hashCode();
+  }
 }

--- a/src/main/java/de/numcodex/feasibility_gui_backend/query/persistence/UserBlacklist.java
+++ b/src/main/java/de/numcodex/feasibility_gui_backend/query/persistence/UserBlacklist.java
@@ -1,14 +1,16 @@
 package de.numcodex.feasibility_gui_backend.query.persistence;
 
-import jakarta.persistence.Column;
-import jakarta.persistence.Entity;
-import jakarta.persistence.GeneratedValue;
-import jakarta.persistence.GenerationType;
-import jakarta.persistence.Id;
-import java.sql.Timestamp;
-import lombok.Data;
+import jakarta.persistence.*;
+import lombok.*;
+import org.hibernate.proxy.HibernateProxy;
 
-@Data
+import java.sql.Timestamp;
+import java.util.Objects;
+
+@Getter
+@Setter
+@ToString
+@RequiredArgsConstructor
 @Entity
 public class UserBlacklist {
 
@@ -21,4 +23,20 @@ public class UserBlacklist {
 
   @Column(name = "blacklisted_at", insertable = false)
   private Timestamp blacklistedAt;
+
+  @Override
+  public final boolean equals(Object o) {
+    if (this == o) return true;
+    if (o == null) return false;
+    Class<?> oEffectiveClass = o instanceof HibernateProxy ? ((HibernateProxy) o).getHibernateLazyInitializer().getPersistentClass() : o.getClass();
+    Class<?> thisEffectiveClass = this instanceof HibernateProxy ? ((HibernateProxy) this).getHibernateLazyInitializer().getPersistentClass() : this.getClass();
+    if (thisEffectiveClass != oEffectiveClass) return false;
+    UserBlacklist that = (UserBlacklist) o;
+    return getId() != null && Objects.equals(getId(), that.getId());
+  }
+
+  @Override
+  public final int hashCode() {
+    return this instanceof HibernateProxy ? ((HibernateProxy) this).getHibernateLazyInitializer().getPersistentClass().hashCode() : getClass().hashCode();
+  }
 }

--- a/src/main/java/de/numcodex/feasibility_gui_backend/terminology/persistence/Context.java
+++ b/src/main/java/de/numcodex/feasibility_gui_backend/terminology/persistence/Context.java
@@ -1,17 +1,24 @@
 package de.numcodex.feasibility_gui_backend.terminology.persistence;
 
 import jakarta.persistence.*;
-import lombok.Data;
-import lombok.EqualsAndHashCode;
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+import lombok.Setter;
+import lombok.ToString;
+import org.hibernate.proxy.HibernateProxy;
+
+import java.util.Objects;
 
 @Entity
-@Data
-@EqualsAndHashCode
+@Getter
+@Setter
+@ToString
+@RequiredArgsConstructor
 public class Context {
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     @Id
     @Column(name = "id", nullable = false)
-    private int id;
+    private Long id;
     @Basic
     @Column(name = "system", nullable = false, length = -1)
     private String system;
@@ -24,4 +31,20 @@ public class Context {
     @Basic
     @Column(name = "display", nullable = false, length = -1)
     private String display;
+
+    @Override
+    public final boolean equals(Object o) {
+        if (this == o) return true;
+        if (o == null) return false;
+        Class<?> oEffectiveClass = o instanceof HibernateProxy ? ((HibernateProxy) o).getHibernateLazyInitializer().getPersistentClass() : o.getClass();
+        Class<?> thisEffectiveClass = this instanceof HibernateProxy ? ((HibernateProxy) this).getHibernateLazyInitializer().getPersistentClass() : this.getClass();
+        if (thisEffectiveClass != oEffectiveClass) return false;
+        Context context = (Context) o;
+        return getId() != null && Objects.equals(getId(), context.getId());
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(id, system, code, version, display);
+    }
 }

--- a/src/main/java/de/numcodex/feasibility_gui_backend/terminology/persistence/ContextualizedTermCode.java
+++ b/src/main/java/de/numcodex/feasibility_gui_backend/terminology/persistence/ContextualizedTermCode.java
@@ -1,13 +1,17 @@
 package de.numcodex.feasibility_gui_backend.terminology.persistence;
 
 import jakarta.persistence.*;
-import lombok.Data;
-import lombok.EqualsAndHashCode;
+import lombok.*;
+import org.hibernate.proxy.HibernateProxy;
+
+import java.util.Objects;
 
 @Entity
 @Table(name = "contextualized_termcode", schema = "public")
-@Data
-@EqualsAndHashCode
+@Getter
+@Setter
+@ToString
+@RequiredArgsConstructor
 public class ContextualizedTermCode {
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     @Id
@@ -25,4 +29,20 @@ public class ContextualizedTermCode {
     @Basic
     @Column(name = "ui_profile_id", nullable = true)
     private Integer uiProfileId;
+
+    @Override
+    public final boolean equals(Object o) {
+        if (this == o) return true;
+        if (o == null) return false;
+        Class<?> oEffectiveClass = o instanceof HibernateProxy ? ((HibernateProxy) o).getHibernateLazyInitializer().getPersistentClass() : o.getClass();
+        Class<?> thisEffectiveClass = this instanceof HibernateProxy ? ((HibernateProxy) this).getHibernateLazyInitializer().getPersistentClass() : this.getClass();
+        if (thisEffectiveClass != oEffectiveClass) return false;
+        ContextualizedTermCode that = (ContextualizedTermCode) o;
+        return getContextTermcodeHash() != null && Objects.equals(getContextTermcodeHash(), that.getContextTermcodeHash());
+    }
+
+    @Override
+    public final int hashCode() {
+        return this instanceof HibernateProxy ? ((HibernateProxy) this).getHibernateLazyInitializer().getPersistentClass().hashCode() : getClass().hashCode();
+    }
 }

--- a/src/main/java/de/numcodex/feasibility_gui_backend/terminology/persistence/ContextualizedTermCodeToCriteriaSet.java
+++ b/src/main/java/de/numcodex/feasibility_gui_backend/terminology/persistence/ContextualizedTermCodeToCriteriaSet.java
@@ -1,13 +1,17 @@
 package de.numcodex.feasibility_gui_backend.terminology.persistence;
 
 import jakarta.persistence.*;
-import lombok.Data;
-import lombok.EqualsAndHashCode;
+import lombok.*;
+import org.hibernate.proxy.HibernateProxy;
+
+import java.util.Objects;
 
 @Entity
 @Table(name = "contextualized_termcode_to_criteria_set", schema = "public")
-@Data
-@EqualsAndHashCode
+@Getter
+@Setter
+@ToString
+@RequiredArgsConstructor
 public class ContextualizedTermCodeToCriteriaSet {
     @Id
     @Basic
@@ -17,4 +21,20 @@ public class ContextualizedTermCodeToCriteriaSet {
     @Basic
     @Column(name = "criteria_set_id", nullable = false)
     private int criteriaSetId;
+
+    @Override
+    public final boolean equals(Object o) {
+        if (this == o) return true;
+        if (o == null) return false;
+        Class<?> oEffectiveClass = o instanceof HibernateProxy ? ((HibernateProxy) o).getHibernateLazyInitializer().getPersistentClass() : o.getClass();
+        Class<?> thisEffectiveClass = this instanceof HibernateProxy ? ((HibernateProxy) this).getHibernateLazyInitializer().getPersistentClass() : this.getClass();
+        if (thisEffectiveClass != oEffectiveClass) return false;
+        ContextualizedTermCodeToCriteriaSet that = (ContextualizedTermCodeToCriteriaSet) o;
+        return getContextTermcodeHash() != null && Objects.equals(getContextTermcodeHash(), that.getContextTermcodeHash());
+    }
+
+    @Override
+    public final int hashCode() {
+        return this instanceof HibernateProxy ? ((HibernateProxy) this).getHibernateLazyInitializer().getPersistentClass().hashCode() : getClass().hashCode();
+    }
 }

--- a/src/main/java/de/numcodex/feasibility_gui_backend/terminology/persistence/CriteriaSet.java
+++ b/src/main/java/de/numcodex/feasibility_gui_backend/terminology/persistence/CriteriaSet.java
@@ -1,19 +1,39 @@
 package de.numcodex.feasibility_gui_backend.terminology.persistence;
 
 import jakarta.persistence.*;
-import lombok.Data;
-import lombok.EqualsAndHashCode;
+import lombok.*;
+import org.hibernate.proxy.HibernateProxy;
+
+import java.util.Objects;
 
 @Entity
 @Table(name = "criteria_set", schema = "public")
-@Data
-@EqualsAndHashCode
+@Getter
+@Setter
+@ToString
+@RequiredArgsConstructor
 public class CriteriaSet {
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     @Id
     @Column(name = "id", nullable = false)
-    private int id;
+    private Long id;
     @Basic
     @Column(name = "url", nullable = false, length = -1)
     private String url;
+
+    @Override
+    public final boolean equals(Object o) {
+        if (this == o) return true;
+        if (o == null) return false;
+        Class<?> oEffectiveClass = o instanceof HibernateProxy ? ((HibernateProxy) o).getHibernateLazyInitializer().getPersistentClass() : o.getClass();
+        Class<?> thisEffectiveClass = this instanceof HibernateProxy ? ((HibernateProxy) this).getHibernateLazyInitializer().getPersistentClass() : this.getClass();
+        if (thisEffectiveClass != oEffectiveClass) return false;
+        CriteriaSet that = (CriteriaSet) o;
+        return getId() != null && Objects.equals(getId(), that.getId());
+    }
+
+    @Override
+    public final int hashCode() {
+        return this instanceof HibernateProxy ? ((HibernateProxy) this).getHibernateLazyInitializer().getPersistentClass().hashCode() : getClass().hashCode();
+    }
 }

--- a/src/main/java/de/numcodex/feasibility_gui_backend/terminology/persistence/Mapping.java
+++ b/src/main/java/de/numcodex/feasibility_gui_backend/terminology/persistence/Mapping.java
@@ -1,17 +1,21 @@
 package de.numcodex.feasibility_gui_backend.terminology.persistence;
 
 import jakarta.persistence.*;
-import lombok.Data;
-import lombok.EqualsAndHashCode;
+import lombok.*;
+import org.hibernate.proxy.HibernateProxy;
+
+import java.util.Objects;
 
 @Entity
-@Data
-@EqualsAndHashCode
+@Getter
+@Setter
+@ToString
+@RequiredArgsConstructor
 public class Mapping {
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     @Id
     @Column(name = "id", nullable = false)
-    private int id;
+    private Long id;
     @Basic
     @Column(name = "name", nullable = false, length = -1)
     private String name;
@@ -21,4 +25,20 @@ public class Mapping {
     @Basic
     @Column(name = "content", columnDefinition = "json", nullable = false)
     private String content;
+
+    @Override
+    public final boolean equals(Object o) {
+        if (this == o) return true;
+        if (o == null) return false;
+        Class<?> oEffectiveClass = o instanceof HibernateProxy ? ((HibernateProxy) o).getHibernateLazyInitializer().getPersistentClass() : o.getClass();
+        Class<?> thisEffectiveClass = this instanceof HibernateProxy ? ((HibernateProxy) this).getHibernateLazyInitializer().getPersistentClass() : this.getClass();
+        if (thisEffectiveClass != oEffectiveClass) return false;
+        Mapping mapping = (Mapping) o;
+        return getId() != null && Objects.equals(getId(), mapping.getId());
+    }
+
+    @Override
+    public final int hashCode() {
+        return this instanceof HibernateProxy ? ((HibernateProxy) this).getHibernateLazyInitializer().getPersistentClass().hashCode() : getClass().hashCode();
+    }
 }

--- a/src/main/java/de/numcodex/feasibility_gui_backend/terminology/persistence/TermCode.java
+++ b/src/main/java/de/numcodex/feasibility_gui_backend/terminology/persistence/TermCode.java
@@ -1,18 +1,22 @@
 package de.numcodex.feasibility_gui_backend.terminology.persistence;
 
 import jakarta.persistence.*;
-import lombok.Data;
-import lombok.EqualsAndHashCode;
+import lombok.*;
+import org.hibernate.proxy.HibernateProxy;
+
+import java.util.Objects;
 
 @Entity
 @Table(name = "termcode", schema = "public")
-@Data
-@EqualsAndHashCode
+@Getter
+@Setter
+@ToString
+@RequiredArgsConstructor
 public class TermCode {
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     @Id
     @Column(name = "id", nullable = false)
-    private int id;
+    private Long id;
     @Basic
     @Column(name = "system", nullable = false, length = -1)
     private String system;
@@ -25,4 +29,20 @@ public class TermCode {
     @Basic
     @Column(name = "display", nullable = false, length = -1)
     private String display;
+
+    @Override
+    public final boolean equals(Object o) {
+        if (this == o) return true;
+        if (o == null) return false;
+        Class<?> oEffectiveClass = o instanceof HibernateProxy ? ((HibernateProxy) o).getHibernateLazyInitializer().getPersistentClass() : o.getClass();
+        Class<?> thisEffectiveClass = this instanceof HibernateProxy ? ((HibernateProxy) this).getHibernateLazyInitializer().getPersistentClass() : this.getClass();
+        if (thisEffectiveClass != oEffectiveClass) return false;
+        TermCode termCode = (TermCode) o;
+        return getId() != null && Objects.equals(getId(), termCode.getId());
+    }
+
+    @Override
+    public final int hashCode() {
+        return this instanceof HibernateProxy ? ((HibernateProxy) this).getHibernateLazyInitializer().getPersistentClass().hashCode() : getClass().hashCode();
+    }
 }

--- a/src/main/java/de/numcodex/feasibility_gui_backend/terminology/persistence/UiProfile.java
+++ b/src/main/java/de/numcodex/feasibility_gui_backend/terminology/persistence/UiProfile.java
@@ -1,22 +1,42 @@
 package de.numcodex.feasibility_gui_backend.terminology.persistence;
 
 import jakarta.persistence.*;
-import lombok.Data;
-import lombok.EqualsAndHashCode;
+import lombok.*;
+import org.hibernate.proxy.HibernateProxy;
+
+import java.util.Objects;
 
 @Entity
 @Table(name = "ui_profile", schema = "public")
-@Data
-@EqualsAndHashCode
+@Getter
+@Setter
+@ToString
+@RequiredArgsConstructor
 public class UiProfile {
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     @Id
     @Column(name = "id", nullable = false)
-    private int id;
+    private Long id;
     @Basic
     @Column(name = "name", nullable = false, length = -1)
     private String name;
     @Basic
     @Column(name = "ui_profile", columnDefinition = "json", nullable = false)
     private String uiProfile;
+
+    @Override
+    public final boolean equals(Object o) {
+        if (this == o) return true;
+        if (o == null) return false;
+        Class<?> oEffectiveClass = o instanceof HibernateProxy ? ((HibernateProxy) o).getHibernateLazyInitializer().getPersistentClass() : o.getClass();
+        Class<?> thisEffectiveClass = this instanceof HibernateProxy ? ((HibernateProxy) this).getHibernateLazyInitializer().getPersistentClass() : this.getClass();
+        if (thisEffectiveClass != oEffectiveClass) return false;
+        UiProfile uiProfile = (UiProfile) o;
+        return getId() != null && Objects.equals(getId(), uiProfile.getId());
+    }
+
+    @Override
+    public final int hashCode() {
+        return this instanceof HibernateProxy ? ((HibernateProxy) this).getHibernateLazyInitializer().getPersistentClass().hashCode() : getClass().hashCode();
+    }
 }

--- a/src/main/java/de/numcodex/feasibility_gui_backend/terminology/persistence/UiProfileContent.java
+++ b/src/main/java/de/numcodex/feasibility_gui_backend/terminology/persistence/UiProfileContent.java
@@ -1,16 +1,18 @@
 package de.numcodex.feasibility_gui_backend.terminology.persistence;
 
+import jakarta.persistence.*;
+import lombok.*;
+import org.hibernate.proxy.HibernateProxy;
+
 import java.io.Serializable;
-import jakarta.persistence.Column;
-import jakarta.persistence.Entity;
-import jakarta.persistence.Id;
-import jakarta.persistence.IdClass;
-import jakarta.persistence.Table;
-import lombok.Data;
+import java.util.Objects;
 
 @Entity(name = "UI_PROFILE")
 @Table(name = "UI_PROFILE_TABLE")
-@Data
+@Getter
+@Setter
+@ToString
+@RequiredArgsConstructor
 @IdClass(Coding.class)
 public class UiProfileContent implements Serializable {
   @Id
@@ -27,4 +29,22 @@ public class UiProfileContent implements Serializable {
 
   @Column(name = "UI_Profile", nullable = false)
   private String uiProfile;
+
+  @Override
+  public final boolean equals(Object o) {
+    if (this == o) return true;
+    if (o == null) return false;
+    Class<?> oEffectiveClass = o instanceof HibernateProxy ? ((HibernateProxy) o).getHibernateLazyInitializer().getPersistentClass() : o.getClass();
+    Class<?> thisEffectiveClass = this instanceof HibernateProxy ? ((HibernateProxy) this).getHibernateLazyInitializer().getPersistentClass() : this.getClass();
+    if (thisEffectiveClass != oEffectiveClass) return false;
+    UiProfileContent that = (UiProfileContent) o;
+    return getSystem() != null && Objects.equals(getSystem(), that.getSystem())
+        && getCode() != null && Objects.equals(getCode(), that.getCode())
+        && getVersion() != null && Objects.equals(getVersion(), that.getVersion());
+  }
+
+  @Override
+  public final int hashCode() {
+    return Objects.hash(system, code, version);
+  }
 }

--- a/src/test/java/de/numcodex/feasibility_gui_backend/dse/DseServiceTest.java
+++ b/src/test/java/de/numcodex/feasibility_gui_backend/dse/DseServiceTest.java
@@ -110,7 +110,7 @@ class DseServiceTest {
   private DseProfile createDummyDseProfile() throws JsonProcessingException {
     var dseProfile = new DseProfile();
 
-    dseProfile.setId(1);
+    dseProfile.setId(1L);
     dseProfile.setUrl("http://example.com");
     dseProfile.setEntry(objectMapper.writeValueAsString(createDummyDseProfileEntry()));
 
@@ -120,7 +120,7 @@ class DseServiceTest {
   private DseProfile createDummyDseProfileWithBogusEntry() {
     var dseProfile = new DseProfile();
 
-    dseProfile.setId(1);
+    dseProfile.setId(1L);
     dseProfile.setUrl("http://example.com");
     dseProfile.setEntry("something that can't be parsed as dse profile");
 

--- a/src/test/java/de/numcodex/feasibility_gui_backend/terminology/TerminologyServiceTest.java
+++ b/src/test/java/de/numcodex/feasibility_gui_backend/terminology/TerminologyServiceTest.java
@@ -157,7 +157,7 @@ class TerminologyServiceTest {
 
     private UiProfile createUiProfile() throws JsonProcessingException {
         var uiProfile = new UiProfile();
-        uiProfile.setId(1);
+        uiProfile.setId(1L);
         uiProfile.setName("example");
         uiProfile.setUiProfile(jsonUtil.writeValueAsString(
             de.numcodex.feasibility_gui_backend.terminology.api.UiProfile.builder()
@@ -170,7 +170,7 @@ class TerminologyServiceTest {
 
     private TermCode createTermCode() {
         TermCode termCode = new TermCode();
-        termCode.setId(1);
+        termCode.setId(1L);
         termCode.setCode("LL2191-6");
         termCode.setSystem("http://loinc.org");
         termCode.setVersion("1.0.0");
@@ -180,7 +180,7 @@ class TerminologyServiceTest {
 
     private Context createContext() {
         Context context = new Context();
-        context.setId(1);
+        context.setId(1L);
         context.setCode("LL2191-6");
         context.setSystem("http://loinc.org");
         context.setVersion("1.0.0");

--- a/src/test/java/de/numcodex/feasibility_gui_backend/terminology/es/CodeableConceptServiceIT.java
+++ b/src/test/java/de/numcodex/feasibility_gui_backend/terminology/es/CodeableConceptServiceIT.java
@@ -17,7 +17,6 @@ import org.testcontainers.images.PullPolicy;
 import org.testcontainers.junit.jupiter.Container;
 import org.testcontainers.junit.jupiter.Testcontainers;
 
-import java.io.IOException;
 import java.util.List;
 
 import static org.assertj.core.api.Assertions.assertThat;

--- a/src/test/java/de/numcodex/feasibility_gui_backend/terminology/persistence/ContextTest.java
+++ b/src/test/java/de/numcodex/feasibility_gui_backend/terminology/persistence/ContextTest.java
@@ -1,0 +1,63 @@
+package de.numcodex.feasibility_gui_backend.terminology.persistence;
+
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+class ContextTest {
+
+  @Test
+  void testEqualsAndHashCode_sameContext() {
+    var context = createContext(1L, "some code", "some display", "some version", "some system");
+
+    assertEquals(context, context);
+    assertEquals(context.hashCode(), context.hashCode());
+  }
+
+  @Test
+  void testEqualsAndHashCode_equalContext() {
+    var context1 = createContext(1L, "some code", "some display", "some version", "some system");
+    var context2 = createContext(1L, "some code", "some display", "some version", "some system");
+
+    assertEquals(context1, context2);
+    assertEquals(context2, context1);
+    assertEquals(context1.hashCode(), context2.hashCode());
+  }
+
+  @Test
+  void testEqualsAndHashCode_differentContext() {
+    var context1 = createContext(1L, "some code", "some display", "some version", "some system");
+    var context2 = createContext(2L, "another code", "another display", "another version", "another system");
+
+    assertNotEquals(context1, context2);
+    assertNotEquals(context2, context1);
+    assertNotEquals(context1.hashCode(), context2.hashCode());
+  }
+
+  @Test
+  void testEquals_nullObjectNotEquals() {
+    var context = createContext(1L, "some code", "some display", "some version", "some system");
+
+    assertNotEquals(context, null);
+    assertNotEquals(null, context);
+  }
+
+  @Test
+  void testEqualsAndHashCode_otherClassNotEquals() {
+    var context = createContext(1L, "some code", "some display", "some version", "some system");
+    Integer i = 10;
+
+    assertNotEquals(context, i);
+    assertNotEquals(context.hashCode(), i.hashCode());
+  }
+
+  private Context createContext(Long id, String code, String display, String version, String system) {
+    var context = new Context();
+    context.setId(id);
+    context.setCode(code);
+    context.setDisplay(display);
+    context.setVersion(version);
+    context.setSystem(system);
+    return context;
+  }
+}

--- a/src/test/java/de/numcodex/feasibility_gui_backend/terminology/persistence/UiProfileContentTest.java
+++ b/src/test/java/de/numcodex/feasibility_gui_backend/terminology/persistence/UiProfileContentTest.java
@@ -1,0 +1,62 @@
+package de.numcodex.feasibility_gui_backend.terminology.persistence;
+
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+class UiProfileContentTest {
+
+  @Test
+  void testEqualsAndHashCode_sameUiProfileContent() {
+    var uiProfileContent = createUiProfileContent("some uiprofile", "some system", "some code", "some version");
+
+    assertEquals(uiProfileContent, uiProfileContent);
+    assertEquals(uiProfileContent.hashCode(), uiProfileContent.hashCode());
+  }
+
+  @Test
+  void testEqualsAndHashCode_equalUiProfileContent() {
+    var uiProfileContent1 = createUiProfileContent("some uiprofile", "some system", "some code", "some version");
+    var uiProfileContent2 = createUiProfileContent("some uiprofile", "some system", "some code", "some version");
+
+    assertEquals(uiProfileContent1, uiProfileContent2);
+    assertEquals(uiProfileContent2, uiProfileContent1);
+    assertEquals(uiProfileContent1.hashCode(), uiProfileContent2.hashCode());
+  }
+
+  @Test
+  void testEqualsAndHashCode_differentUiProfileContent() {
+    var uiProfileContent1 = createUiProfileContent("some uiprofile", "some system", "some code", "some version");
+    // the actual ui profile is not part of the equals method
+    var uiProfileContent2 = createUiProfileContent("some uiprofile", "another system", "another code", "another version");
+
+    assertNotEquals(uiProfileContent1, uiProfileContent2);
+    assertNotEquals(uiProfileContent2, uiProfileContent1);
+    assertNotEquals(uiProfileContent1.hashCode(), uiProfileContent2.hashCode());
+  }
+
+  @Test
+  void testEquals_nullObjectNotEquals() {
+    var uiProfileContent = createUiProfileContent("some uiprofile", "some system", "some code", "some version");
+
+    assertNotEquals(uiProfileContent, null);
+  }
+
+  @Test
+  void testEqualsAndHashCode_otherClassNotEquals() {
+    var uiProfileContent = createUiProfileContent("some uiprofile", "some system", "some code", "some version");
+    Integer i = 10;
+
+    assertNotEquals(uiProfileContent, i);
+    assertNotEquals(uiProfileContent.hashCode(), i.hashCode());
+  }
+
+  private UiProfileContent createUiProfileContent(String uiProfile, String system, String code, String version) {
+    UiProfileContent uiProfileContent = new UiProfileContent();
+    uiProfileContent.setUiProfile(uiProfile);
+    uiProfileContent.setSystem(system);
+    uiProfileContent.setCode(code);
+    uiProfileContent.setVersion(version);
+    return uiProfileContent;
+  }
+}


### PR DESCRIPTION
- Remove @Data and @EqualsAndHashCode annotations and replace them with @Getter @Setter @ToString (excluding lazily loaded variables) and custom equals and hashcode methods
- Change id datatype from int to Long in entity classes