### PR TITLE
#363 - Add "results" to GET query/{queryId} response

### DIFF
--- a/src/main/java/de/numcodex/feasibility_gui_backend/query/QueryHandlerService.java
+++ b/src/main/java/de/numcodex/feasibility_gui_backend/query/QueryHandlerService.java
@@ -203,6 +203,7 @@ public class QueryHandlerService {
                     .content(jsonUtil.readValue(in.getQueryContent().getQueryContent(), StructuredQuery.class))
                     .label(savedQuery.get().getLabel())
                     .comment(savedQuery.get().getComment())
+                    .totalNumberOfPatients(savedQuery.get().getResultSize())
                     .build();
         } else {
             return Query.builder()

--- a/src/main/java/de/numcodex/feasibility_gui_backend/query/api/Query.java
+++ b/src/main/java/de/numcodex/feasibility_gui_backend/query/api/Query.java
@@ -11,7 +11,8 @@ public record Query(
     @JsonProperty long id,
     @JsonProperty StructuredQuery content,
     @JsonProperty String label,
-    @JsonProperty String comment
+    @JsonProperty String comment,
+    @JsonProperty long totalNumberOfPatients
 ) {
 
 }

--- a/src/main/java/de/numcodex/feasibility_gui_backend/query/v4/QueryHandlerRestController.java
+++ b/src/main/java/de/numcodex/feasibility_gui_backend/query/v4/QueryHandlerRestController.java
@@ -309,6 +309,7 @@ public class QueryHandlerRestController {
             .content(structuredQueryValidation.annotateStructuredQuery(query.content(), skipValidation))
             .label(query.label())
             .comment(query.comment())
+            .totalNumberOfPatients(query.totalNumberOfPatients())
             .build();
     return new ResponseEntity<>(annotatedQuery, HttpStatus.OK);
   }


### PR DESCRIPTION
- Add the totalNumberOfPatients from the saved query object back to the response when reading a query
- the demanded queryId from the issue is already present as "id" - so nothing to do here imho