### PR TITLE
#376 - Allow Empty Search with filters

### DIFF
--- a/src/main/java/de/numcodex/feasibility_gui_backend/terminology/es/CodeableConceptService.java
+++ b/src/main/java/de/numcodex/feasibility_gui_backend/terminology/es/CodeableConceptService.java
@@ -78,15 +78,24 @@ public class CodeableConceptService {
       });
     }
 
-    var mmQuery = new MultiMatchQuery.Builder()
-        .query(keyword)
-        .fields(List.of("termcode.display", "termcode.code^2"))
-        .build();
+    BoolQuery boolQuery;
 
-    var boolQuery = new BoolQuery.Builder()
-        .must(List.of(mmQuery._toQuery()))
-        .filter(filterTerms.isEmpty() ? List.of() : filterTerms)
-        .build();
+    if (keyword.isEmpty()) {
+      boolQuery = new BoolQuery.Builder()
+          .filter(filterTerms.isEmpty() ? List.of() : filterTerms)
+          .build();
+
+    } else {
+      var mmQuery = new MultiMatchQuery.Builder()
+          .query(keyword)
+          .fields(List.of("termcode.display", "termcode.code^2"))
+          .build();
+
+      boolQuery = new BoolQuery.Builder()
+          .must(List.of(mmQuery._toQuery()))
+          .filter(filterTerms.isEmpty() ? List.of() : filterTerms)
+          .build();
+    }
 
     var query = new NativeQueryBuilder()
         .withQuery(boolQuery._toQuery())

--- a/src/test/java/de/numcodex/feasibility_gui_backend/terminology/es/CodeableConceptServiceIT.java
+++ b/src/test/java/de/numcodex/feasibility_gui_backend/terminology/es/CodeableConceptServiceIT.java
@@ -97,6 +97,14 @@ public class CodeableConceptServiceIT {
   }
 
   @Test
+  void testPerformCodeableConceptSearchWithRepoAndPaging_findsAllWithNoKeyword() {
+    var page = assertDoesNotThrow (() -> codeableConceptService.performCodeableConceptSearchWithRepoAndPaging("", List.of(), 20, 0));
+
+    assertNotNull(page);
+    assertThat(page.getTotalHits()).isEqualTo(3L);
+  }
+
+  @Test
   void testPerformCodeableConceptSearchWithRepoAndPaging_findsTwoOrOneDependingOnFilter() {
     var pageNoFilter = assertDoesNotThrow (() -> codeableConceptService.performCodeableConceptSearchWithRepoAndPaging("ba", List.of(), 20, 0));
     var pageOneFilter = assertDoesNotThrow (() -> codeableConceptService.performCodeableConceptSearchWithRepoAndPaging("ba", List.of("some-value-set"), 20, 0));

--- a/src/test/java/de/numcodex/feasibility_gui_backend/terminology/es/CodeableConceptServiceTest.java
+++ b/src/test/java/de/numcodex/feasibility_gui_backend/terminology/es/CodeableConceptServiceTest.java
@@ -95,6 +95,17 @@ class CodeableConceptServiceTest {
   }
 
   @Test
+  void testPerformCodeableConceptSearchWithRepoAndPaging_succeedsWithEmptyKeyword() {
+    SearchHits<CodeableConceptDocument> dummySearchHitsPage = createDummySearchHitsPage(5);
+    doReturn(dummySearchHitsPage).when(operations).search(any(NativeQuery.class), any(Class.class));
+
+    var result = assertDoesNotThrow(() -> codeableConceptService.performCodeableConceptSearchWithRepoAndPaging("", List.of(), 20, 0));
+
+    assertNotNull(result);
+    assertThat(result.getTotalHits()).isNotZero();
+  }
+
+  @Test
   void testGetSearchResultEntryByCode_succeeds() {
     CodeableConceptDocument dummyCodeableConceptDocument = createDummyCodeableConceptDocument("1");
     doReturn(Optional.of(dummyCodeableConceptDocument)).when(repository).findById(any());

--- a/src/test/java/de/numcodex/feasibility_gui_backend/terminology/es/TerminologyEsServiceIT.java
+++ b/src/test/java/de/numcodex/feasibility_gui_backend/terminology/es/TerminologyEsServiceIT.java
@@ -108,6 +108,13 @@ public class TerminologyEsServiceIT {
   }
 
   @Test
+  void testPerformOntologySearchWithPaging_findsAllWithNoKeyword() {
+    var page = terminologyEsService.performOntologySearchWithPaging("", null, null, null, null, false, 20, 0);
+    assertThat(page).isNotNull();
+    assertThat(page.totalHits()).isEqualTo(4L);
+  }
+
+  @Test
   void testPerformOntologySearchWithPaging_oneResult() {
     var page = terminologyEsService.performOntologySearchWithPaging("Hauttransplan", null, null, null, null, false, 20, 0);
     assertThat(page).isNotNull();

--- a/src/test/java/de/numcodex/feasibility_gui_backend/terminology/es/TerminologyEsServiceTest.java
+++ b/src/test/java/de/numcodex/feasibility_gui_backend/terminology/es/TerminologyEsServiceTest.java
@@ -150,6 +150,23 @@ public class TerminologyEsServiceTest {
     assertThat(searchResult.results()).containsExactlyInAnyOrderElementsOf(dummySearchHitsPage.getSearchHits().stream().map(sh -> EsSearchResultEntry.of(sh.getContent())).toList());
   }
 
+  @ParameterizedTest
+  @MethodSource("generateArgumentsForTestPerformOntologySearchWithPaging")
+  void testPerformOntologySearchWithPagingEmptyKeyword(List<String> criteriaSets, List<String> context, List<String> kdsModule, List<String> terminology, Boolean availability, Integer pageSize, Integer page) {
+    int totalHits = new Random().nextInt(100);
+    SearchHits<OntologyListItemDocument> dummySearchHitsPage = createDummySearchHitsPage(totalHits);
+    doReturn(dummySearchHitsPage).when(operations).search(any(NativeQuery.class), any(Class.class));
+
+    var searchResult = assertDoesNotThrow(
+        () -> terminologyEsService.performOntologySearchWithPaging(
+            "", criteriaSets, context, kdsModule, terminology, availability, pageSize, page)
+    );
+
+    assertThat(searchResult.totalHits()).isEqualTo(totalHits);
+    assertThat(searchResult.results().size()).isEqualTo(dummySearchHitsPage.getTotalHits());
+    assertThat(searchResult.results()).containsExactlyInAnyOrderElementsOf(dummySearchHitsPage.getSearchHits().stream().map(sh -> EsSearchResultEntry.of(sh.getContent())).toList());
+  }
+
   @Test
   void testPerformOntologySearchWithRepoAndPaging_throwsOnInvalidPageSize() {
     assertThrows(IllegalArgumentException.class, () -> terminologyEsService.performOntologySearchWithPaging(


### PR DESCRIPTION
- Change score modification to add an offset instead of multiplying when availability > 0
- remove the inner "must" part of the bool query when searchterm is empty