### PR TITLE
#431 - Parameters missing for dse profile data in swagger documentation

### DIFF
--- a/src/main/resources/static/v3/api-docs/swagger.yaml
+++ b/src/main/resources/static/v3/api-docs/swagger.yaml
@@ -917,6 +917,16 @@ paths:
       summary: Get the profile data for the submitted ids
       description: Get profile data for all submitted ids. If a profile is not found, an error message will be supplied.
       operationId: getProfileData
+      parameters:
+        - name: ids
+          in: query
+          style: form
+          explode: false
+          description: A comma-separated list of IDs (here - mostly URLs) of the entries that shall be retrieved.
+          required: true
+          schema:
+            type: string
+            example: https://www.medizininformatik-initiative.de/fhir/core/modul-labor/StructureDefinition/ObservationLab,https://www.medizininformatik-initiative.de/fhir/core/modul-prozedur/StructureDefinition/Procedure
       responses:
         200:
           description: Success, returning profiles - may contain profiles with error messages


### PR DESCRIPTION
- added parameters for GET dse/profile-data