### PR TITLE
#433 - Change endpoint /codeable-concept/entry/{id} to allow for multiple ids

### DIFF
--- a/.github/scripts/post-elastic-test-queries.sh
+++ b/.github/scripts/post-elastic-test-queries.sh
@@ -95,12 +95,12 @@ else
     exit 1
 fi
 
-response=$(curl -s -w "%{http_code}" --header "Authorization: Bearer $access_token" -o response_body "http://localhost:8091/api/v4/codeable-concept/entry/$cc_example_id")
+response=$(curl -s -w "%{http_code}" --header "Authorization: Bearer $access_token" -o response_body "http://localhost:8091/api/v4/codeable-concept/entry?ids=$cc_example_id")
 http_code="${response: -3}"
 json_body=$(cat response_body)
 
 if [ "$http_code" -eq 200 ]; then
-    if echo "$json_body" | jq -e '.termCode.code and .termCode.code != ""' | grep -q true; then
+    if echo "$json_body" | jq -e '.[0].termCode.code and .[0].termCode.code != ""' | grep -q true; then
         echo "OK response with non-empty array on get cc by id"
     else
         echo "Empty or nonexistent response on get cc by id"

--- a/src/main/java/de/numcodex/feasibility_gui_backend/terminology/api/CodeableConceptEntry.java
+++ b/src/main/java/de/numcodex/feasibility_gui_backend/terminology/api/CodeableConceptEntry.java
@@ -10,11 +10,13 @@ import java.util.List;
 
 @Builder
 public record CodeableConceptEntry(
+    String id,
     TermCode termCode,
     DisplayEntry display
 ) {
   public static CodeableConceptEntry of(CodeableConceptDocument document) {
     return CodeableConceptEntry.builder()
+        .id(document.id())
         .termCode(document.termCode())
         .display(DisplayEntry.builder()
             .original(document.display().original())

--- a/src/main/java/de/numcodex/feasibility_gui_backend/terminology/es/CodeableConceptService.java
+++ b/src/main/java/de/numcodex/feasibility_gui_backend/terminology/es/CodeableConceptService.java
@@ -6,7 +6,6 @@ import de.numcodex.feasibility_gui_backend.terminology.api.CcSearchResult;
 import de.numcodex.feasibility_gui_backend.terminology.api.CodeableConceptEntry;
 import de.numcodex.feasibility_gui_backend.terminology.es.model.CodeableConceptDocument;
 import de.numcodex.feasibility_gui_backend.terminology.es.repository.CodeableConceptEsRepository;
-import de.numcodex.feasibility_gui_backend.terminology.es.repository.OntologyItemNotFoundException;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnExpression;
@@ -56,9 +55,11 @@ public class CodeableConceptService {
         .build();
   }
 
-  public CodeableConceptEntry getSearchResultEntryByCode(String code) {
-    var document = repo.findById(code).orElseThrow(OntologyItemNotFoundException::new);
-    return CodeableConceptEntry.of(document);
+  public List<CodeableConceptEntry> getSearchResultsEntryByIds(List<String> ids) {
+    var documents = repo.findAllById(ids);
+    var codeableConceptEntries = new ArrayList<CodeableConceptEntry>();
+    documents.forEach(d -> codeableConceptEntries.add(CodeableConceptEntry.of(d)));
+    return codeableConceptEntries;
   }
 
   private SearchHits<CodeableConceptDocument> findByCodeOrDisplay(String keyword,

--- a/src/main/java/de/numcodex/feasibility_gui_backend/terminology/v4/CodeableConceptRestController.java
+++ b/src/main/java/de/numcodex/feasibility_gui_backend/terminology/v4/CodeableConceptRestController.java
@@ -16,7 +16,7 @@ import java.util.List;
 @CrossOrigin
 public class CodeableConceptRestController {
 
-  private CodeableConceptService codeableConceptService;
+  private final CodeableConceptService codeableConceptService;
 
   @Autowired
   public CodeableConceptRestController(CodeableConceptService codeableConceptService) {
@@ -33,8 +33,8 @@ public class CodeableConceptRestController {
         .performCodeableConceptSearchWithRepoAndPaging(keyword, valueSets, pageSize, page);
   }
 
-  @GetMapping(value = "/entry/{code}",  produces = MediaType.APPLICATION_JSON_VALUE)
-  public CodeableConceptEntry getCodeableConceptByCode(@PathVariable("code") String code) {
-    return codeableConceptService.getSearchResultEntryByCode(code);
+  @GetMapping(value = "/entry",  produces = MediaType.APPLICATION_JSON_VALUE)
+  public List<CodeableConceptEntry> getCodeableConceptsByCode(@RequestParam List<String> ids) {
+    return codeableConceptService.getSearchResultsEntryByIds(ids);
   }
 }

--- a/src/main/resources/static/v3/api-docs/swagger.yaml
+++ b/src/main/resources/static/v3/api-docs/swagger.yaml
@@ -869,20 +869,22 @@ paths:
           description: Unauthorized - please login first
         403:
           description: Forbidden - insufficient access rights
-  /codeable-concept/entry/{id}:
+  /codeable-concept/entry:
     get:
       tags:
         - codeable concepts
-      summary: Search for codeable concepts by code or display. Optionally filter by value sets
-      operationId: getCodeableConceptByCode
+      summary: Retrieve Codeable Concepts by their ids
+      operationId: getCodeableConceptsByCode
       parameters:
-        - name: id
-          in: path
-          description: The id (contextualized termcode hash) of the entry that shall be retrieved
+        - name: ids
+          in: query
+          style: form
+          explode: false
+          description: The ids (contextualized termcode hash) of the entry that shall be retrieved
           required: true
           schema:
             type: string
-            example: 203e04cd-4f0a-321b-b1ad-9ec6d211e0a8
+            example: 203e04cd-4f0a-321b-b1ad-9ec6d211e0a8,203e04cd-4f0a-321b-b1ad-9ec6d211e0a9
       responses:
         200:
           description: Ok, return the codeable concept
@@ -1459,6 +1461,9 @@ components:
     CodeableConceptEntry:
       type: object
       properties:
+        id:
+          type: string
+          format: uuid
         termCode:
           $ref: "#/components/schemas/TermCode"
         display:

--- a/src/test/java/de/numcodex/feasibility_gui_backend/terminology/es/CodeableConceptServiceIT.java
+++ b/src/test/java/de/numcodex/feasibility_gui_backend/terminology/es/CodeableConceptServiceIT.java
@@ -20,6 +20,7 @@ import org.testcontainers.junit.jupiter.Testcontainers;
 import java.util.List;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
@@ -117,18 +118,21 @@ public class CodeableConceptServiceIT {
   }
 
   @Test
-  void testGetSearchResultEntryByCode_succeeds() {
-    var result = assertDoesNotThrow(() -> codeableConceptService.getSearchResultEntryByCode("A1.1"));
+  void testGetSearchResultsEntryByIds_succeeds() {
+    var result = assertDoesNotThrow(() -> codeableConceptService.getSearchResultsEntryByIds(List.of("A1.1")));
 
     assertNotNull(result);
-    Assertions.assertEquals("bar", result.termCode().display());
-    Assertions.assertEquals("A1.1", result.termCode().code());
-    Assertions.assertEquals("2012", result.termCode().version());
-    Assertions.assertEquals("another-system", result.termCode().system());
+    Assertions.assertFalse(result.isEmpty());
+    Assertions.assertEquals("bar", result.get(0).termCode().display());
+    Assertions.assertEquals("A1.1", result.get(0).termCode().code());
+    Assertions.assertEquals("2012", result.get(0).termCode().version());
+    Assertions.assertEquals("another-system", result.get(0).termCode().system());
   }
 
   @Test
-  void testGetSearchResultEntryByCode_throwsOnNotFound() {
-    assertThrows(OntologyItemNotFoundException.class, () -> codeableConceptService.getSearchResultEntryByCode("something-not-found"));
+  void testGetSearchResultsEntryByIds_emptyOnNotFound() {
+    var result = assertDoesNotThrow(() -> codeableConceptService.getSearchResultsEntryByIds(List.of("something-not-found")));
+    assertNotNull(result);
+    Assertions.assertTrue(result.isEmpty());
   }
 }


### PR DESCRIPTION
- Endpoint is changed to /codeable-concept/entry, expecting a list of ids as query parameter
- CodeableConceptEntry now included the id in the returned json