### PR TITLE
#446 - Search in original entry of display if no translations are available

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -148,7 +148,7 @@ jobs:
     needs: tests
     runs-on: ubuntu-latest
     env:
-      ONTOLOGY_GIT_TAG: v3.0.2-alpha.2
+      ONTOLOGY_GIT_TAG: v3.0.2-alpha.5
       ELASTIC_HOST: http://localhost:9200
       ELASTIC_FILEPATH: https://github.com/medizininformatik-initiative/fhir-ontology-generator/releases/download/TAGPLACEHOLDER/
       ELASTIC_FILENAME: elastic.zip

--- a/pom.xml
+++ b/pom.xml
@@ -27,7 +27,7 @@
     <java.version>17</java.version>
     <mockwebserver.version>4.12.0</mockwebserver.version>
     <okhttp3.version>4.10.0</okhttp3.version>
-    <ontology-tag>v3.0.2-alpha.2</ontology-tag>
+    <ontology-tag>v3.0.2-alpha.5</ontology-tag>
   </properties>
 
   <dependencies>
@@ -423,7 +423,7 @@
                   <goal>download-single</goal>
                 </goals>
                 <configuration>
-                  <url>https://github.com/medizininformatik-initiative/fhir-ontology-generator/releases/download/${ontology-tag}/</url>
+                  <url>https://github.com/medizininformatik-initiative/fhir-ontology-generator/releases/download/${ontology-tag}</url>
                   <fromFile>backend.zip</fromFile>
                   <toDir>${ontoDirectory.download}</toDir>
                 </configuration>
@@ -435,7 +435,7 @@
                   <goal>download-single</goal>
                 </goals>
                 <configuration>
-                  <url>https://github.com/medizininformatik-initiative/fhir-ontology-generator/releases/download/${ontology-tag}/</url>
+                  <url>https://github.com/medizininformatik-initiative/fhir-ontology-generator/releases/download/${ontology-tag}</url>
                   <fromFile>mapping.zip</fromFile>
                   <toDir>${ontoDirectory.download}</toDir>
                 </configuration>

--- a/src/main/java/de/numcodex/feasibility_gui_backend/terminology/es/TerminologyEsService.java
+++ b/src/main/java/de/numcodex/feasibility_gui_backend/terminology/es/TerminologyEsService.java
@@ -156,13 +156,19 @@ public class TerminologyEsService {
           .filter(filterTerms.isEmpty() ? List.of() : filterTerms)
           .build();
     } else {
-      var mmQuery = new MultiMatchQuery.Builder()
+      var mmQueryWithTranslations = new MultiMatchQuery.Builder()
           .query(keyword)
           .fields(List.of("display.de", "display.en", "termcode^2"))
           .build();
 
+      var mmQueryWithOriginal = new MultiMatchQuery.Builder()
+          .query(keyword)
+          .fields(List.of("display.original", "termcode^2"))
+          .build();
+
       boolQuery = new BoolQuery.Builder()
-          .must(List.of(mmQuery._toQuery()))
+          .should(List.of(mmQueryWithTranslations._toQuery(), mmQueryWithOriginal._toQuery()))
+          .minimumShouldMatch("1")
           .filter(filterTerms.isEmpty() ? List.of() : filterTerms)
           .build();
     }

--- a/src/test/resources/de/numcodex/feasibility_gui_backend/terminology/es/codeable_concept.json
+++ b/src/test/resources/de/numcodex/feasibility_gui_backend/terminology/es/codeable_concept.json
@@ -86,7 +86,8 @@
         "properties": {
           "original": {
             "type": "text",
-            "index": false
+            "analyzer": "edge_ngram_analyzer_include_punctuation",
+            "search_analyzer": "lowercase_analyzer"
           },
           "de": {
             "type": "text",

--- a/src/test/resources/de/numcodex/feasibility_gui_backend/terminology/es/ontology.json
+++ b/src/test/resources/de/numcodex/feasibility_gui_backend/terminology/es/ontology.json
@@ -99,7 +99,8 @@
         "properties": {
           "original": {
             "type": "text",
-            "index": false
+            "analyzer": "edge_ngram_analyzer_include_punctuation",
+            "search_analyzer": "lowercase_analyzer"
           },
           "de": {
             "type": "text",


### PR DESCRIPTION
**Warning** This will not work until [ontology generator issue 152](https://github.com/medizininformatik-initiative/fhir-ontology-generator/issues/152) is done and a new ontology is available for download. Otherwise tests will always fail.
And after the changes are done, this requires to set the new ontology tag here.

- Modify ontology search query to look in original field
- Modify codeable concept search query to look in original field