### PR TITLE
#460 - provide count of "sent" queries

### DIFF
--- a/src/main/java/de/numcodex/feasibility_gui_backend/query/QueryHandlerService.java
+++ b/src/main/java/de/numcodex/feasibility_gui_backend/query/QueryHandlerService.java
@@ -6,6 +6,8 @@ import de.numcodex.feasibility_gui_backend.query.api.Query;
 import de.numcodex.feasibility_gui_backend.query.api.QueryTemplate;
 import de.numcodex.feasibility_gui_backend.query.api.SavedQuery;
 import de.numcodex.feasibility_gui_backend.query.api.*;
+import de.numcodex.feasibility_gui_backend.query.api.status.QueryQuota;
+import de.numcodex.feasibility_gui_backend.query.api.status.QueryQuotaEntry;
 import de.numcodex.feasibility_gui_backend.query.dispatch.QueryDispatchException;
 import de.numcodex.feasibility_gui_backend.query.dispatch.QueryDispatcher;
 import de.numcodex.feasibility_gui_backend.query.persistence.*;
@@ -322,5 +324,23 @@ public class QueryHandlerService {
         } else {
             throw new QueryNotFoundException();
         }
+    }
+
+    public QueryQuota getSentQueryStatistics(String userName, int softAmount, int softInterval, int hardAmount, int hardInterval) {
+        var softUsed = queryRepository.countQueriesByAuthorInTheLastNMinutes(userName, softInterval);
+        var hardUsed = queryRepository.countQueriesByAuthorInTheLastNMinutes(userName, hardInterval);
+
+        return QueryQuota.builder()
+            .soft(QueryQuotaEntry.builder()
+                .intervalInMinutes(softInterval)
+                .limit(softAmount)
+                .used(softUsed.intValue())
+                .build())
+            .hard(QueryQuotaEntry.builder()
+                .intervalInMinutes(hardInterval)
+                .limit(hardAmount)
+                .used(hardUsed.intValue())
+                .build())
+            .build();
     }
 }

--- a/src/main/java/de/numcodex/feasibility_gui_backend/query/api/status/QueryQuota.java
+++ b/src/main/java/de/numcodex/feasibility_gui_backend/query/api/status/QueryQuota.java
@@ -1,0 +1,13 @@
+package de.numcodex.feasibility_gui_backend.query.api.status;
+
+import com.fasterxml.jackson.annotation.JsonInclude;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import lombok.Builder;
+
+@JsonInclude()
+@Builder
+public record QueryQuota(
+    @JsonProperty("softLimit") QueryQuotaEntry soft,
+    @JsonProperty("hardLimit") QueryQuotaEntry hard
+) {
+}

--- a/src/main/java/de/numcodex/feasibility_gui_backend/query/api/status/QueryQuotaEntry.java
+++ b/src/main/java/de/numcodex/feasibility_gui_backend/query/api/status/QueryQuotaEntry.java
@@ -1,0 +1,14 @@
+package de.numcodex.feasibility_gui_backend.query.api.status;
+
+import com.fasterxml.jackson.annotation.JsonInclude;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import lombok.Builder;
+
+@JsonInclude()
+@Builder
+public record QueryQuotaEntry(
+    @JsonProperty("intervalInMinutes") int intervalInMinutes,
+    @JsonProperty("used") int used,
+    @JsonProperty("total") int limit
+) {
+}

--- a/src/main/java/de/numcodex/feasibility_gui_backend/query/persistence/Query.java
+++ b/src/main/java/de/numcodex/feasibility_gui_backend/query/persistence/Query.java
@@ -2,6 +2,7 @@ package de.numcodex.feasibility_gui_backend.query.persistence;
 
 import jakarta.persistence.*;
 import lombok.*;
+import org.hibernate.annotations.CreationTimestamp;
 import org.hibernate.proxy.HibernateProxy;
 
 import java.sql.Timestamp;
@@ -19,6 +20,7 @@ public class Query {
     private Long id;
 
     @Column(name = "created_at", insertable = false, updatable = false)
+    @CreationTimestamp
     private Timestamp createdAt;
 
     @Column(name = "created_by", updatable = false)

--- a/src/main/java/de/numcodex/feasibility_gui_backend/query/persistence/QueryRepository.java
+++ b/src/main/java/de/numcodex/feasibility_gui_backend/query/persistence/QueryRepository.java
@@ -1,8 +1,11 @@
 package de.numcodex.feasibility_gui_backend.query.persistence;
 
+import java.sql.Timestamp;
 import java.util.List;
 import java.util.Optional;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Modifying;
+import org.springframework.data.jpa.repository.NativeQuery;
 
 public interface QueryRepository extends JpaRepository<Query, Long> {
 
@@ -15,11 +18,13 @@ public interface QueryRepository extends JpaRepository<Query, Long> {
   @org.springframework.data.jpa.repository.Query("SELECT t.createdBy FROM Query t WHERE t.id = ?1")
   Optional<String> getAuthor(Long queryId);
 
-  @org.springframework.data.jpa.repository.Query(value = """
-    SELECT count (*) FROM query WHERE created_by = ?1 AND created_at > (current_timestamp - (?2 * interval '1 minute'))""", nativeQuery = true)
+  @NativeQuery(value = "SELECT count (*) FROM query WHERE created_by = ?1 AND created_at > (current_timestamp - (?2 * interval '1 minute'))")
   Long countQueriesByAuthorInTheLastNMinutes(String authorId, int minutes);
 
-  @org.springframework.data.jpa.repository.Query(value = """
-    SELECT EXTRACT (EPOCH from ( SELECT (current_timestamp - created_at) from query WHERE created_by = ?1 ORDER BY created_at desc LIMIT 1 OFFSET ?2))""", nativeQuery = true)
+  @NativeQuery(value = "SELECT EXTRACT (EPOCH from ( SELECT (current_timestamp - created_at) from query WHERE created_by = ?1 ORDER BY created_at desc LIMIT 1 OFFSET ?2))")
   Long getAgeOfNToLastQueryInSeconds(String authorId, int offset);
+
+  @Modifying(clearAutomatically = true)
+  @NativeQuery(value = "UPDATE query SET created_at = ?2 where id =?1;")
+  void updateCreationDate(Long queryId, Timestamp timestamp);
 }

--- a/src/main/java/de/numcodex/feasibility_gui_backend/query/v4/QueryHandlerRestController.java
+++ b/src/main/java/de/numcodex/feasibility_gui_backend/query/v4/QueryHandlerRestController.java
@@ -65,13 +65,13 @@ public class QueryHandlerRestController {
   @Value("${app.privacy.quota.soft.create.amount}")
   private int quotaSoftCreateAmount;
 
-  @Value("${app.privacy.quota.soft.create.intervalminutes}")
+  @Value("${app.privacy.quota.soft.create.intervalMinutes}")
   private int quotaSoftCreateIntervalMinutes;
 
   @Value("${app.privacy.quota.hard.create.amount}")
   private int quotaHardCreateAmount;
 
-  @Value("${app.privacy.quota.hard.create.intervalminutes}")
+  @Value("${app.privacy.quota.hard.create.intervalMinutes}")
   private int quotaHardCreateIntervalMinutes;
 
   @Value("${app.privacy.threshold.sites}")
@@ -363,6 +363,16 @@ public class QueryHandlerRestController {
         .build();
 
     return new ResponseEntity<>(resultRateLimit, HttpStatus.OK);
+  }
+
+  @GetMapping("/quota")
+  public ResponseEntity<Object> getQueryCreateQuota(Authentication authentication) {
+    var sentQueryStatistics = queryHandlerService.getSentQueryStatistics(authentication.getName(),
+        quotaSoftCreateAmount,
+        quotaSoftCreateIntervalMinutes,
+        quotaHardCreateAmount,
+        quotaHardCreateIntervalMinutes);
+    return new ResponseEntity<>(sentQueryStatistics, HttpStatus.OK);
   }
 
   @GetMapping("/{id}" + WebSecurityConfig.PATH_SUMMARY_RESULT)

--- a/src/test/java/de/numcodex/feasibility_gui_backend/query/v4/QueryHandlerRestControllerIT.java
+++ b/src/test/java/de/numcodex/feasibility_gui_backend/query/v4/QueryHandlerRestControllerIT.java
@@ -8,6 +8,8 @@ import de.numcodex.feasibility_gui_backend.common.api.Criterion;
 import de.numcodex.feasibility_gui_backend.common.api.TermCode;
 import de.numcodex.feasibility_gui_backend.query.QueryHandlerService;
 import de.numcodex.feasibility_gui_backend.query.api.status.FeasibilityIssue;
+import de.numcodex.feasibility_gui_backend.query.api.status.QueryQuota;
+import de.numcodex.feasibility_gui_backend.query.api.status.QueryQuotaEntry;
 import de.numcodex.feasibility_gui_backend.query.api.status.ValidationIssue;
 import de.numcodex.feasibility_gui_backend.query.api.validation.StructuredQueryValidatorSpringConfig;
 import de.numcodex.feasibility_gui_backend.query.dispatch.QueryDispatchException;
@@ -651,6 +653,15 @@ public class QueryHandlerRestControllerIT {
                 .andExpect(status().isUnauthorized());
     }
 
+    @Test
+    @WithMockUser(roles = {"DATAPORTAL_TEST_USER"}, username = "test")
+    public void testGetQueryQuota() throws Exception {
+        doReturn(createDummyQueryQuota()).when(queryHandlerService).getSentQueryStatistics(any(String.class), anyInt(), anyInt(), anyInt(), anyInt());
+
+        mockMvc.perform(get(URI.create(PATH_API + PATH_QUERY + "/quota")).with(csrf()))
+            .andExpect(status().isOk());
+    }
+
     @NotNull
     private static StructuredQuery createValidStructuredQuery() {
         var termCode = TermCode.builder()
@@ -834,5 +845,25 @@ public class QueryHandlerRestControllerIT {
                 .totalNumberOfPatients(queryResultLines.stream().map(QueryResultLine::numberOfPatients).reduce(0L, Long::sum))
                 .resultLines(queryResultLines)
                 .build();
+    }
+
+    @NotNull
+    private static QueryQuota createDummyQueryQuota() {
+        return QueryQuota.builder()
+            .hard(
+                QueryQuotaEntry.builder()
+                    .used(5)
+                    .limit(10)
+                    .intervalInMinutes(100)
+                    .build()
+            )
+            .soft(
+                QueryQuotaEntry.builder()
+                    .used(20)
+                    .limit(50)
+                    .intervalInMinutes(1000)
+                    .build()
+            )
+            .build();
     }
 }

--- a/src/test/resources/application.yml
+++ b/src/test/resources/application.yml
@@ -33,7 +33,7 @@ app:
       hard:
         create:
           amount: 5
-          intervalMinutes: 2
+          intervalMinutes: 10
       read:
         resultSummary:
           pollingIntervalSeconds: 1


### PR DESCRIPTION
- add endpoint /query/statistics to retrieve the amount of queries the user sent in the last 24h and last 168h
- Description was kinda sparse...so please let me know if you want it somehow different than I implemented it
- I assumed it should be "in the last 24h" and not "since midnight", same for the week, it's in the last 168h, not since monday 12am