### PR TITLE
Only Push Docker Image Tag 'latest' for Stable Versions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -226,6 +226,19 @@ jobs:
     steps:
     - uses: actions/checkout@v4
 
+    - name: Parse version
+      uses: nowsprinting/check-version-format-action@v4
+      id: version
+      with:
+        prefix: 'v'
+
+    - name: Report invalid version
+      if: ${{ steps.version.outputs.is_valid != 'true' }}
+      uses: actions/github-script@v7
+      with:
+        script: |
+            core.setFailed('Tag name "${{ github.ref_name }}" is not a valid semantic version!')
+
     - name: Set up JDK 22
       uses: actions/setup-java@v4
       with:
@@ -243,11 +256,10 @@ jobs:
         servers: |
           [{"id": "mii", "username": "${{ github.actor }}", "password": "${{ secrets.GITHUB_TOKEN }}"}]
 
-    - name: Prepare Version
-      id: prep
+    - name: Prepare Docker Repository
+      id: repo
       run: |
         echo ::set-output name=repository::$(echo $GITHUB_REPOSITORY | tr '[:upper:]' '[:lower:]')
-        echo ::set-output name=version::${GITHUB_REF#refs/tags/v}
 
     - name: Maven Package
       run: mvn -Pdownload-ontology -B -DskipTests package
@@ -271,6 +283,6 @@ jobs:
         context: .
         platforms: linux/amd64,linux/arm64
         tags: |
-          ghcr.io/${{ steps.prep.outputs.repository }}:latest
-          ghcr.io/${{ steps.prep.outputs.repository }}:${{ steps.prep.outputs.version }}
+          ghcr.io/${{ steps.repo.outputs.repository }}:${{ steps.version.outputs.full_without_prefix }}
+          ${{ steps.version.outputs.is_stable == 'true' && format('ghcr.io/{0}:latest', steps.repo.outputs.repository) || null}}
         push: true


### PR DESCRIPTION
Only allow tags starting with `v` followed by a valid [semantic version](https://semver.org/) to be released and only stable versions get the docker image `latest` tag attached.