### PR TITLE
Add Feasibility FHIR Resource Version to Profile URLs

### DIFF
--- a/src/main/java/de/numcodex/feasibility_gui_backend/query/broker/dsf/DSFQueryManager.java
+++ b/src/main/java/de/numcodex/feasibility_gui_backend/query/broker/dsf/DSFQueryManager.java
@@ -41,9 +41,9 @@ import static org.hl7.fhir.r4.model.Task.TaskStatus.REQUESTED;
 class DSFQueryManager implements QueryManager {
 
     private static final String INSTANTIATE_CANONICAL = "http://medizininformatik-initiative.de/bpe/Process/feasibilityRequest|1.0";
-    private static final String REQUEST_PROFILE = "http://medizininformatik-initiative.de/fhir/StructureDefinition/feasibility-task-request";
-    private static final String MEASURE_PROFILE = "http://medizininformatik-initiative.de/fhir/StructureDefinition/feasibility-measure";
-    private static final String LIBRARY_PROFILE = "http://medizininformatik-initiative.de/fhir/StructureDefinition/feasibility-library";
+    private static final String REQUEST_PROFILE = "http://medizininformatik-initiative.de/fhir/StructureDefinition/feasibility-task-request|1.0";
+    private static final String MEASURE_PROFILE = "http://medizininformatik-initiative.de/fhir/StructureDefinition/feasibility-measure|1.0";
+    private static final String LIBRARY_PROFILE = "http://medizininformatik-initiative.de/fhir/StructureDefinition/feasibility-library|1.0";
     private static final String REQUEST_URL_TASK = "Task";
     private static final String REQUEST_URL_LIBRARY = "Library";
     private static final String REQUEST_URL_MEASURE = "Measure";

--- a/src/test/java/de/numcodex/feasibility_gui_backend/query/broker/dsf/DSFQueryManagerTest.java
+++ b/src/test/java/de/numcodex/feasibility_gui_backend/query/broker/dsf/DSFQueryManagerTest.java
@@ -147,13 +147,13 @@ public class DSFQueryManagerTest {
         assertEquals("http://medizininformatik-initiative.de/bpe/Process/feasibilityRequest|1.0",
                 task.getInstantiatesCanonical());
         assertEquals(1, task.getMeta().getProfile().stream().filter(p -> p.getValueAsString()
-                        .equals("http://medizininformatik-initiative.de/fhir/StructureDefinition/feasibility-task-request"))
+                .equals("http://medizininformatik-initiative.de/fhir/StructureDefinition/feasibility-task-request|1.0"))
                 .count());
         assertEquals(1, library.getMeta().getProfile().stream().filter(p -> p.getValueAsString()
-                        .equals("http://medizininformatik-initiative.de/fhir/StructureDefinition/feasibility-library"))
+                .equals("http://medizininformatik-initiative.de/fhir/StructureDefinition/feasibility-library|1.0"))
                 .count());
         assertEquals(1, measure.getMeta().getProfile().stream().filter(p -> p.getValueAsString()
-                        .equals("http://medizininformatik-initiative.de/fhir/StructureDefinition/feasibility-measure"))
+                .equals("http://medizininformatik-initiative.de/fhir/StructureDefinition/feasibility-measure|1.0"))
                 .count());
         assertEquals(36, measure.getGroupFirstRep().getPopulationFirstRep().getId().length());
         assertEquals("http://medizininformatik-initiative.de/fhir/CodeSystem/feasibility", measureReferenceSystem);


### PR DESCRIPTION
Fix rejection of task creation when having unversioned profile url of task match wrong structure definition version in DSF FHIR server.