### PR TITLE
#491 - Reading the crtdl part of a dataquery without cohortDefinition fails

### DIFF
--- a/src/main/java/de/numcodex/feasibility_gui_backend/query/v5/DataqueryHandlerRestController.java
+++ b/src/main/java/de/numcodex/feasibility_gui_backend/query/v5/DataqueryHandlerRestController.java
@@ -123,7 +123,7 @@ public class DataqueryHandlerRestController {
           .display(dataquery.content().display())
           .version(dataquery.content().version())
           .dataExtraction(dataquery.content().dataExtraction())
-          .cohortDefinition(structuredQueryValidation.annotateStructuredQuery(dataquery.content().cohortDefinition(), skipValidation))
+          .cohortDefinition(dataquery.content().cohortDefinition() == null ? null : structuredQueryValidation.annotateStructuredQuery(dataquery.content().cohortDefinition(), skipValidation))
           .build();
       return new ResponseEntity<>(crtdlWithInvalidCritiera, HttpStatus.OK);
     } catch (JsonProcessingException e) {


### PR DESCRIPTION
- add check if ccdl is null