### PR TITLE
#499 - Improve log output when blacklisting user

### DIFF
--- a/src/main/java/de/numcodex/feasibility_gui_backend/query/v5/FeasibilityQueryHandlerRestController.java
+++ b/src/main/java/de/numcodex/feasibility_gui_backend/query/v5/FeasibilityQueryHandlerRestController.java
@@ -30,6 +30,8 @@ import reactor.core.publisher.Mono;
 
 import java.net.URI;
 import java.security.Principal;
+import java.time.Duration;
+import java.time.LocalDateTime;
 import java.util.List;
 import java.util.Optional;
 import java.util.Set;
@@ -119,9 +121,16 @@ public class FeasibilityQueryHandlerRestController {
         userId, quotaHardCreateInterval);
     if (!isPowerUser && (quotaHardCreateAmount
         <= amountOfQueriesByUserAndHardInterval)) {
+      var intervalEnd = LocalDateTime.now();
+      var intervalStart = intervalEnd.minus(Duration.parse(quotaHardCreateInterval));
       log.info(
-          "User {} exceeded hard limit and is not a power user. Blacklisting...",
-          userId);
+          "Blacklisting user {} for exceeding quota without being poweruser. Allowed: {} queries per {}. The user posted {} queries between {} and {}",
+          userId,
+          quotaHardCreateAmount,
+          quotaHardCreateInterval,
+          amountOfQueriesByUserAndHardInterval,
+          intervalStart,
+          intervalEnd);
       UserBlacklist userBlacklist = new UserBlacklist();
       userBlacklist.setUserId(userId);
       userBlacklistRepository.save(userBlacklist);


### PR DESCRIPTION
Output is now:

Blacklisting user <userid> for exceeding quota without being poweruser. Allowed: 50 queries per P1W. The user posted 50 queries between 2025-04-28T15:20:20.650035424 and 2025-05-05T15:20:20.650035424