### PR TITLE
#507 - Update dependencies

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -85,7 +85,7 @@
     <dependency>
       <groupId>com.nimbusds</groupId>
       <artifactId>oauth2-oidc-sdk</artifactId>
-      <version>11.20.1</version>
+      <version>11.24</version>
     </dependency>
 
     <dependency>
@@ -113,13 +113,13 @@
     <dependency>
       <groupId>org.springdoc</groupId>
       <artifactId>springdoc-openapi-starter-webmvc-ui</artifactId>
-      <version>2.6.0</version>
+      <version>2.8.6</version>
     </dependency>
 
     <dependency>
       <groupId>com.github.erosb</groupId>
       <artifactId>everit-json-schema</artifactId>
-      <version>1.14.2</version>
+      <version>1.14.6</version>
       <exclusions>
         <exclusion>
           <groupId>org.json</groupId>
@@ -135,13 +135,13 @@
     <dependency>
       <groupId>org.json</groupId>
       <artifactId>json</artifactId>
-      <version>20240303</version>
+      <version>20250107</version>
     </dependency>
 
     <dependency>
       <groupId>org.aktin</groupId>
       <artifactId>broker-client</artifactId>
-      <version>1.5.0</version>
+      <version>1.5.1</version>
     </dependency>
 
     <dependency>
@@ -182,7 +182,7 @@
     <dependency>
       <groupId>org.apache.commons</groupId>
       <artifactId>commons-text</artifactId>
-      <version>1.12.0</version>
+      <version>1.13.1</version>
     </dependency>
 
     <dependency>
@@ -212,7 +212,7 @@
     <dependency>
       <groupId>com.github.ben-manes.caffeine</groupId>
       <artifactId>caffeine</artifactId>
-      <version>3.1.8</version>
+      <version>3.2.0</version>
     </dependency>
 
     <dependency>
@@ -247,7 +247,7 @@
     <dependency>
       <groupId>org.mockito</groupId>
       <artifactId>mockito-core</artifactId>
-      <version>4.11.0</version>
+      <version>5.17.0</version>
       <scope>test</scope>
     </dependency>
 
@@ -267,7 +267,7 @@
     <dependency>
       <groupId>com.github.dasniko</groupId>
       <artifactId>testcontainers-keycloak</artifactId>
-      <version>3.5.1</version>
+      <version>3.7.0</version>
       <scope>test</scope>
     </dependency>
 
@@ -306,7 +306,7 @@
     <dependency>
       <groupId>io.projectreactor</groupId>
       <artifactId>reactor-test</artifactId>
-      <version>3.6.11</version>
+      <version>3.8.0-M3</version>
       <scope>test</scope>
     </dependency>
 
@@ -380,7 +380,7 @@
       <plugin>
         <groupId>org.jacoco</groupId>
         <artifactId>jacoco-maven-plugin</artifactId>
-        <version>0.8.12</version>
+        <version>0.8.13</version>
         <executions>
           <execution>
             <id>prepare-agent</id>


### PR DESCRIPTION
com.nimbusds:oauth2-oidc-sdk:11.20.1 > 11.24
org.springdoc:springdoc-openapi-starter-webmvc-ui:2.6.0 > 2.8.6 com.github.erosb:everit-json-schema:1.14.2 > 1.14.6 org.json:json:20240303 > 20250107
org.aktin:broker-client:1.5.0 > 1.5.1
org.apache.commons:commons-text:1.12.0 > 1.13.1
com.github.ben-manes.caffeine:caffeine:3.1.8 > 3.2.0 org.mockito:mockito-core:4.11.0 > 5.17.0
com.github.dasniko:testcontainers-keycloak:3.5.1 > 3.7.0 io.projectreactor:reactor-test:3.6.11 > 3.8.0-M3
org.jacoco:jacoco-maven-plugin:0.8.12 > 0.8.13