### PR TITLE
Implement FHIR Async Request Pattern for Direct Broker using CQL

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,6 +59,7 @@ handles obfuscation by adding or subtracting a random number <=5.
 | BROKER_CLIENT_DIRECT_AUTH_OAUTH_CLIENT_ID     | Client ID to use when authenticating at OpenID Connect provider                                 | `foo_client`                          |         |
 | BROKER_CLIENT_DIRECT_AUTH_OAUTH_CLIENT_SECRET | Client secret to use when authenticating at OpenID Connect provider                             | `verysecurepassword`                  |         |
 | BROKER_CLIENT_DIRECT_USE_CQL                  | Whether to use a CQL server or not.                                                             |                                       | `false` |
+| BROKER_CLIENT_DIRECT_CQL_USE_ASYNC            | Whether to use the FHIR Async Request Pattern when using a CQL server.                          |                                       | `false` |
 | BROKER_CLIENT_DIRECT_TIMEOUT                  | Maximum time waiting for response from FLARE or FHIR server (ISO 8601 duration)                 | `PT24H`                               | `PT20S` |
 | BROKER_CLIENT_OBFUSCATE_RESULT_COUNT          | Whether the result counts retrieved from the direct broker shall be obfuscated                  |                                       | `false` |
 

--- a/src/main/java/de/numcodex/feasibility_gui_backend/query/broker/NoOpInterceptor.java
+++ b/src/main/java/de/numcodex/feasibility_gui_backend/query/broker/NoOpInterceptor.java
@@ -1,0 +1,15 @@
+package de.numcodex.feasibility_gui_backend.query.broker;
+
+import ca.uhn.fhir.rest.client.api.IClientInterceptor;
+import ca.uhn.fhir.rest.client.api.IHttpRequest;
+import ca.uhn.fhir.rest.client.api.IHttpResponse;
+
+import java.io.IOException;
+
+public final class NoOpInterceptor implements IClientInterceptor {
+    @Override
+    public void interceptResponse(IHttpResponse theResponse) throws IOException {}
+
+    @Override
+    public void interceptRequest(IHttpRequest theRequest) {}
+}

--- a/src/main/java/de/numcodex/feasibility_gui_backend/query/broker/direct/AsyncRequestException.java
+++ b/src/main/java/de/numcodex/feasibility_gui_backend/query/broker/direct/AsyncRequestException.java
@@ -1,0 +1,17 @@
+package de.numcodex.feasibility_gui_backend.query.broker.direct;
+
+import java.io.IOException;
+
+public class AsyncRequestException extends IOException {
+
+    private static final long serialVersionUID = 1L;
+
+    public AsyncRequestException(String message) {
+        super(message);
+    }
+
+    public AsyncRequestException(String message, Throwable e) {
+        super(message, e);
+    }
+
+}

--- a/src/main/java/de/numcodex/feasibility_gui_backend/query/broker/direct/AsyncRequestExecutor.java
+++ b/src/main/java/de/numcodex/feasibility_gui_backend/query/broker/direct/AsyncRequestExecutor.java
@@ -1,0 +1,146 @@
+package de.numcodex.feasibility_gui_backend.query.broker.direct;
+
+import ca.uhn.fhir.util.DateUtils;
+import lombok.extern.slf4j.Slf4j;
+import org.apache.http.Header;
+import org.apache.http.HttpClientConnection;
+import org.apache.http.HttpException;
+import org.apache.http.HttpHeaders;
+import org.apache.http.HttpRequest;
+import org.apache.http.HttpResponse;
+import org.apache.http.HttpStatus;
+import org.apache.http.client.config.RequestConfig;
+import org.apache.http.client.methods.RequestBuilder;
+import org.apache.http.client.protocol.HttpClientContext;
+import org.apache.http.protocol.BasicHttpContext;
+import org.apache.http.protocol.HttpContext;
+import org.apache.http.protocol.HttpRequestExecutor;
+
+import java.io.IOException;
+import java.math.BigDecimal;
+import java.net.URI;
+import java.time.Duration;
+import java.time.Instant;
+import java.util.Arrays;
+import java.util.Date;
+import java.util.List;
+import java.util.Optional;
+import java.util.regex.Pattern;
+
+@Slf4j
+public class AsyncRequestExecutor extends HttpRequestExecutor {
+    private static final int WAIT_DURATION_MAX_MS = 30000;
+    private static final int WAIT_DURATION_MIN_MS = 250;
+    private static final Pattern NUMBER_PATTERN = Pattern.compile("\\d+");
+
+    @Override
+    public HttpResponse execute(HttpRequest request, HttpClientConnection conn, HttpContext context)
+            throws IOException, HttpException {
+        request.addHeader("Prefer", "respond-async");
+        var startTime = Instant.now();
+        var timeout = Duration
+                .ofMillis(((RequestConfig) context.getAttribute(HttpClientContext.REQUEST_CONFIG)).getSocketTimeout());
+
+        HttpResponse initialResponse = super.execute(request, conn, context);
+
+        if (initialResponse.getStatusLine().getStatusCode() == HttpStatus.SC_ACCEPTED) {
+            Header contentLocation = initialResponse.getFirstHeader("Content-Location");
+            if (contentLocation == null) {
+                throw new AsyncRequestException("No Content-Location provided for polling");
+            }
+            return pollUntilReady(URI.create(contentLocation.getValue()), startTime, timeout, request, conn, context,
+                    initialResponse);
+        }
+
+        return initialResponse;
+    }
+
+    private HttpResponse pollUntilReady(URI location, Instant startTime, Duration timeout, HttpRequest origRequest,
+                                        HttpClientConnection conn, HttpContext origContext, HttpResponse response)
+            throws IOException, HttpException {
+
+        var waitDuration = Duration.ZERO;
+        var request = Arrays.stream(origRequest.getAllHeaders())
+                .filter(h -> !List.of(HttpHeaders.CONTENT_TYPE, HttpHeaders.CONTENT_LENGTH).contains(h.getName()))
+                .collect(RequestBuilder::get, (builder, header) -> builder.addHeader(header), (b1, b2) -> {})
+                .setUri(location.getPath())
+                .build();
+        var context = new BasicHttpContext(origContext);
+
+        do {
+            try {
+                log.debug("waiting {} before polling '{}'", waitDuration, location);
+                Thread.sleep(waitDuration.toMillis());
+                var elapsed = Duration.between(startTime, Instant.now());
+
+                if (elapsed.compareTo(timeout) > 0) {
+                    log.error("Polling status of asynchronous request at {} timed out after {} (timeout limit: {})",
+                            location, elapsed, timeout);
+                    return deleteAsyncRequest(request, conn, context);
+                }
+
+                response = super.execute(request, conn, context);
+            } catch (InterruptedException e) {
+                log.error("Polling status of asynchronous request at {} interrupted: {}", location, e.getMessage());
+                return deleteAsyncRequest(request, conn, context);
+            }
+            waitDuration = nextWaitDuration(response, waitDuration, location);
+        } while (response.getStatusLine().getStatusCode() == HttpStatus.SC_ACCEPTED);
+
+        return response;
+    }
+
+    private HttpResponse deleteAsyncRequest(HttpRequest request, HttpClientConnection conn, HttpContext context)
+            throws AsyncRequestException {
+        try {
+            var deleteRequest = Arrays.stream(request.getAllHeaders())
+                    .collect(RequestBuilder::delete, (builder, header) -> builder.addHeader(header), (b1, b2) -> {})
+                    .setUri(request.getRequestLine().getUri())
+                    .build();
+            var response = super.execute(deleteRequest, conn, context);
+
+            if (response.getStatusLine().getStatusCode() == HttpStatus.SC_ACCEPTED) {
+                log.info("Asynchronous request at {} cancelled", request.getRequestLine().getUri());
+                return response;
+            } else {
+                log.error("Got http status {} cancelling asynchronous request at {}",
+                        response.getStatusLine().getStatusCode(), request.getRequestLine().getUri());
+                return response;
+            }
+        } catch (IOException | HttpException e) {
+            throw new AsyncRequestException(
+                    "Failed to cancel asynchronous request at %s".formatted(request.getRequestLine().getUri()),
+                    e);
+        }
+    }
+
+    private Duration nextWaitDuration(HttpResponse response, Duration previousWaitDuration, URI location) {
+        if (response.containsHeader(HttpHeaders.RETRY_AFTER)) {
+            var retryHeader = response.getFirstHeader(HttpHeaders.RETRY_AFTER);
+            return Optional.ofNullable(retryHeader)
+                    .map(h -> h.getValue())
+                    .map(DateUtils::parseDate)
+                    .map(Date::getTime)
+                    .map(t -> Duration.ofMillis(Math.max(t - System.currentTimeMillis(), 0)))
+                    .orElseGet(() -> Optional.ofNullable(retryHeader)
+                            .map(h -> h.getValue())
+                            .filter(h -> NUMBER_PATTERN.matcher(h).matches())
+                            .map(BigDecimal::new)
+                            .map(BigDecimal::longValue)
+                            .map(Duration::ofSeconds)
+                            .orElseGet(() -> {
+                                log.error("Response from {} contains invalid Retry-After header value: {}",
+                                        location,
+                                        retryHeader.getValue());
+                                return exponentialWaitDuration(previousWaitDuration);
+                            }));
+        } else {
+            return exponentialWaitDuration(previousWaitDuration);
+        }
+    }
+
+    private Duration exponentialWaitDuration(Duration previousWaitDuration) {
+        return Duration.ofMillis(Math.min(WAIT_DURATION_MAX_MS,
+                Math.max(WAIT_DURATION_MIN_MS, previousWaitDuration.toMillis() * 2)));
+    }
+}

--- a/src/main/java/de/numcodex/feasibility_gui_backend/query/broker/direct/FhirConnector.java
+++ b/src/main/java/de/numcodex/feasibility_gui_backend/query/broker/direct/FhirConnector.java
@@ -4,15 +4,23 @@ import ca.uhn.fhir.rest.client.api.IGenericClient;
 import ca.uhn.fhir.rest.param.DateParam;
 import ca.uhn.fhir.rest.param.StringParam;
 import ca.uhn.fhir.rest.server.exceptions.BaseServerResponseException;
-import java.io.IOException;
+import lombok.extern.slf4j.Slf4j;
 import org.hl7.fhir.r4.model.Bundle;
 import org.hl7.fhir.r4.model.Measure;
 import org.hl7.fhir.r4.model.MeasureReport;
+import org.hl7.fhir.r4.model.OperationOutcome;
 import org.hl7.fhir.r4.model.Parameters;
+import org.hl7.fhir.r4.model.Parameters.ParametersParameterComponent;
+import org.hl7.fhir.r4.model.Resource;
 import org.springframework.stereotype.Component;
+
+import java.io.IOException;
+import java.util.List;
+import java.util.Optional;
 
 
 @Component
+@Slf4j
 public class FhirConnector {
 
   private final IGenericClient client;
@@ -36,24 +44,56 @@ public class FhirConnector {
 
   /**
    * Get the {@link MeasureReport} for a previously transmitted {@link Measure}
+   *
    * @param measureUri the identifier of the {@link Measure}
    * @return the retrieved {@link MeasureReport} from the server
-   * @throws IOException if the communication with the FHIR server fails due to any client or server error
+   * @throws IOException if the communication with the FHIR server fails due to any client/server error or the response
+   *             did not contain a {@link MeasureReport}
    */
   public MeasureReport evaluateMeasure(String measureUri) throws IOException {
     try {
-      return client.operation()
-          .onType(Measure.class)
-          .named("evaluate-measure")
-          .withSearchParameter(Parameters.class, "measure", new StringParam(measureUri))
-          .andSearchParameter("periodStart", new DateParam("1900"))
-          .andSearchParameter("periodEnd", new DateParam("2100"))
-          .useHttpGet()
-          .returnResourceType(MeasureReport.class)
-          .execute();
+        return Optional
+                .of(client.operation()
+                        .onType(Measure.class)
+                        .named("evaluate-measure")
+                        .withSearchParameter(Parameters.class, "measure", new StringParam(measureUri))
+                        .andSearchParameter("periodStart", new DateParam("1900"))
+                        .andSearchParameter("periodEnd", new DateParam("2100"))
+                        .useHttpGet()
+                        .preferResponseTypes(List.of(MeasureReport.class, Bundle.class, OperationOutcome.class))
+                        .execute())
+                .filter(Parameters::hasParameter)
+                .map(Parameters::getParameterFirstRep)
+                .filter(ParametersParameterComponent::hasResource)
+                .map(ParametersParameterComponent::getResource)
+                .flatMap(this::toMeasureReport)
+                .orElseThrow(() -> new IOException("An error occurred while trying to evaluate a measure report"));
     } catch (BaseServerResponseException e) {
       throw new IOException("An error occurred while trying to evaluate a measure report", e);
     }
   }
 
+  private Optional<MeasureReport> toMeasureReport(Resource r) {
+      if (r instanceof MeasureReport) {
+          return Optional.of((MeasureReport) r);
+      } else if (r instanceof Bundle) {
+          var report = Optional.of((Bundle) r)
+                  .filter(Bundle::hasEntry)
+                  .map(Bundle::getEntryFirstRep)
+                  .filter(Bundle.BundleEntryComponent::hasResource)
+                  .map(Bundle.BundleEntryComponent::getResource)
+                  .filter(MeasureReport.class::isInstance)
+                  .map(MeasureReport.class::cast);
+          if (report.isEmpty()) {
+              log.error("Failed to extract MeasureReport from Bundle");
+          }
+          return report;
+      } else if (r instanceof OperationOutcome) {
+          log.error("Operation failed: {}", ((OperationOutcome) r).getIssueFirstRep().getDiagnostics());
+          return Optional.empty();
+      } else {
+          log.error("Response contains unexpected resource type: {}", r.getClass().getSimpleName());
+          return Optional.empty();
+      }
+  }
 }

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -88,6 +88,8 @@ app:
             secret: ${BROKER_CLIENT_DIRECT_AUTH_OAUTH_CLIENT_SECRET:}
       enabled: ${BROKER_CLIENT_DIRECT_ENABLED:false}
       useCql: ${BROKER_CLIENT_DIRECT_USE_CQL:false}
+      cql:
+        useAsyncRequestPattern: ${BROKER_CLIENT_DIRECT_CQL_USE_ASYNC:false}
       obfuscateResultCount: ${BROKER_CLIENT_OBFUSCATE_RESULT_COUNT:false}
       timeout: ${BROKER_CLIENT_DIRECT_TIMEOUT:PT20S}
     aktin:

--- a/src/test/java/de/numcodex/feasibility_gui_backend/query/broker/direct/DirectSpringConfigIT.java
+++ b/src/test/java/de/numcodex/feasibility_gui_backend/query/broker/direct/DirectSpringConfigIT.java
@@ -173,7 +173,7 @@ public class DirectSpringConfigIT {
     @DisplayName("flare webClient fails not getting 5s delayed response before given timeout of 2s")
     void flareClientFailsReachingTimeout() throws Exception {
         var timeout = Duration.ofSeconds(2);
-        var delta = Duration.ofSeconds(1);
+        var delta = Duration.ofSeconds(3);
         var delay = 5;
         mockWebServer.enqueue(new MockResponse().setResponseCode(200).setBody("Foo").setBodyDelay(delay, SECONDS));
         directSpringConfig = new DirectSpringConfig(false,
@@ -228,7 +228,7 @@ public class DirectSpringConfigIT {
         var metadata = new ClassPathResource("fhir-metadata.json", DirectSpringConfigIT.class)
                 .getContentAsString(Charsets.UTF_8);
         var timeout = Duration.ofSeconds(2);
-        var delta = Duration.ofSeconds(1);
+        var delta = Duration.ofSeconds(3);
         var delay = 5;
         var response = new MockResponse().setResponseCode(200)
                 .setHeaders(Headers.of("Content-Type", "application/fhir+json"))

--- a/src/test/java/de/numcodex/feasibility_gui_backend/query/broker/direct/DirectSpringConfigIT.java
+++ b/src/test/java/de/numcodex/feasibility_gui_backend/query/broker/direct/DirectSpringConfigIT.java
@@ -3,6 +3,7 @@ package de.numcodex.feasibility_gui_backend.query.broker.direct;
 import ca.uhn.fhir.context.FhirContext;
 import ca.uhn.fhir.rest.client.api.IGenericClient;
 import ca.uhn.fhir.rest.client.exceptions.FhirClientConnectionException;
+import ca.uhn.fhir.rest.server.exceptions.BaseServerResponseException;
 import com.google.common.base.Charsets;
 import dasniko.testcontainers.keycloak.KeycloakContainer;
 import io.netty.handler.timeout.ReadTimeoutException;
@@ -11,227 +12,636 @@ import okhttp3.mockwebserver.Dispatcher;
 import okhttp3.mockwebserver.MockResponse;
 import okhttp3.mockwebserver.MockWebServer;
 import okhttp3.mockwebserver.RecordedRequest;
+import org.hl7.fhir.r4.model.Binary;
 import org.hl7.fhir.r4.model.CapabilityStatement;
-import org.junit.jupiter.api.*;
+import org.hl7.fhir.r4.model.Parameters;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.boot.test.system.CapturedOutput;
+import org.springframework.boot.test.system.OutputCaptureExtension;
 import org.springframework.core.io.ClassPathResource;
 import org.springframework.http.HttpHeaders;
+import org.springframework.http.HttpMethod;
 import org.springframework.web.reactive.function.client.WebClient;
 import org.springframework.web.reactive.function.client.WebClientResponseException;
-import org.testcontainers.junit.jupiter.Container;
 import org.testcontainers.junit.jupiter.Testcontainers;
 
 import java.io.IOException;
 import java.nio.charset.StandardCharsets;
 import java.time.Duration;
 import java.time.Instant;
+import java.time.ZoneId;
+import java.time.format.DateTimeFormatter;
 import java.util.Base64;
+import java.util.Locale;
 
 import static java.util.concurrent.TimeUnit.SECONDS;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.assertj.core.api.Assertions.from;
 
 @Testcontainers
 @ExtendWith(MockitoExtension.class)
+@ExtendWith(OutputCaptureExtension.class)
 public class DirectSpringConfigIT {
 
-  @Container
-  public static KeycloakContainer keycloak = new KeycloakContainer("quay.io/keycloak/keycloak:26.2")
-      .withAdminUsername("admin")
-      .withAdminPassword("admin")
-      .withRealmImportFile(new ClassPathResource("realm-test.json", DirectSpringConfigIT.class).getPath())
-      .withReuse(true);
+    public static KeycloakContainer keycloak = new KeycloakContainer("quay.io/keycloak/keycloak:26.2")
+            .withAdminUsername("admin")
+            .withAdminPassword("admin")
+            .withRealmImportFile(new ClassPathResource("realm-test.json", DirectSpringConfigIT.class).getPath())
+            .withReuse(true);
 
-  private static final String USERNAME = "some-user-123";
-  private static final String PASSWORD = "vALBAi95WW84x3";
-  MockWebServer mockWebServer;
+    private static final String USERNAME = "some-user-123";
+    private static final String PASSWORD = "vALBAi95WW84x3";
+    MockWebServer mockWebServer;
 
-  private DirectSpringConfig directSpringConfig;
+    private DirectSpringConfig directSpringConfig;
 
-  @BeforeEach
-  void setUp() throws IOException {
-    mockWebServer = new MockWebServer();
-    mockWebServer.start();
-  }
+    @BeforeEach
+    void setUp() throws IOException {
+        mockWebServer = new MockWebServer();
+        mockWebServer.start();
+    }
 
-  @AfterEach
-  void tearDown() throws IOException {
-    mockWebServer.shutdown();
-  }
+    @AfterEach
+    void tearDown() throws IOException {
+        mockWebServer.shutdown();
+    }
 
-  @Test
-  @DisplayName("Direct broker FLARE webclient request with basic authentication")
-  void flareClientWithCredentials() throws InterruptedException {
-    mockWebServer.enqueue(new MockResponse().setResponseCode(200).setBody("Foo"));
-    directSpringConfig = new DirectSpringConfig(true, String.format("http://localhost:%s", mockWebServer.getPort()),
-            null, USERNAME, PASSWORD, null, null, null, Duration.ofSeconds(10));
-    var authHeaderValue = "Basic "
-        + Base64.getEncoder().encodeToString((USERNAME + ":" + PASSWORD).getBytes(StandardCharsets.UTF_8));
+    @Test
+    @DisplayName("Direct broker FLARE webclient request with basic authentication")
+    void flareClientWithCredentials() throws InterruptedException {
+        mockWebServer.enqueue(new MockResponse().setResponseCode(200).setBody("Foo"));
+        directSpringConfig = new DirectSpringConfig(true, String.format("http://localhost:%s", mockWebServer.getPort()),
+                null, USERNAME, PASSWORD, null, null, null, Duration.ofSeconds(10), false);
+        var authHeaderValue = "Basic "
+                + Base64.getEncoder().encodeToString((USERNAME + ":" + PASSWORD).getBytes(StandardCharsets.UTF_8));
 
-    WebClient webClient = directSpringConfig.directWebClientFlare();
+        WebClient webClient = directSpringConfig.directWebClientFlare();
 
-    webClient
-        .get()
-        .uri("/foo")
-        .retrieve()
-        .bodyToMono(String.class)
-        .subscribe(responseBody -> {
-        });
-    var recordedRequest = mockWebServer.takeRequest();
-    assertThat(recordedRequest.getHeader(HttpHeaders.AUTHORIZATION)).isEqualTo(authHeaderValue);
-  }
+        webClient
+                .get()
+                .uri("/foo")
+                .retrieve()
+                .bodyToMono(String.class)
+                .subscribe(responseBody -> {});
+        var recordedRequest = mockWebServer.takeRequest();
+        assertThat(recordedRequest.getHeader(HttpHeaders.AUTHORIZATION)).isEqualTo(authHeaderValue);
+    }
 
-  @Test
-  @DisplayName("Direct broker FLARE webclient request with no authentication")
-  void flareClientWithoutCredentials() throws InterruptedException {
-    mockWebServer.enqueue(new MockResponse().setResponseCode(200).setBody("Foo"));
-    directSpringConfig = new DirectSpringConfig(true, String.format("http://localhost:%s", mockWebServer.getPort()),
-            null, null, null, null, null, null, Duration.ofSeconds(10));
+    @Test
+    @DisplayName("Direct broker FLARE webclient request with no authentication")
+    void flareClientWithoutCredentials() throws InterruptedException {
+        mockWebServer.enqueue(new MockResponse().setResponseCode(200).setBody("Foo"));
+        directSpringConfig = new DirectSpringConfig(true, String.format("http://localhost:%s", mockWebServer.getPort()),
+                null, null, null, null, null, null, Duration.ofSeconds(10), false);
 
-    WebClient webClient = directSpringConfig.directWebClientFlare();
+        WebClient webClient = directSpringConfig.directWebClientFlare();
 
-    webClient
-        .get()
-        .uri("/foo")
-        .retrieve()
-        .bodyToMono(String.class)
-        .subscribe(responseBody -> {
-        });
-    var recordedRequest = mockWebServer.takeRequest();
-    assertThat(recordedRequest.getHeader(HttpHeaders.AUTHORIZATION)).isNull();
-  }
+        webClient
+                .get()
+                .uri("/foo")
+                .retrieve()
+                .bodyToMono(String.class)
+                .subscribe(responseBody -> {});
+        var recordedRequest = mockWebServer.takeRequest();
+        assertThat(recordedRequest.getHeader(HttpHeaders.AUTHORIZATION)).isNull();
+    }
 
-  @Test
-  @DisplayName("Direct broker FHIR client request with OAuth token")
-  void fhirClientWithOAuthCredentials() throws InterruptedException, IOException {
-    String metadata = new ClassPathResource("fhir-metadata.json", DirectSpringConfigIT.class)
-        .getContentAsString(Charsets.UTF_8);
-    mockWebServer.setDispatcher(new Dispatcher() {
+    @Test
+    @DisplayName("Direct broker FHIR client request with OAuth token")
+    void fhirClientWithOAuthCredentials() throws InterruptedException, IOException {
+        keycloak.start();
+        try {
+            String metadata = new ClassPathResource("fhir-metadata.json", DirectSpringConfigIT.class)
+                    .getContentAsString(Charsets.UTF_8);
+            mockWebServer.setDispatcher(new Dispatcher() {
 
-      @Override
-      public MockResponse dispatch(RecordedRequest arg0) throws InterruptedException {
-        if ("/metadata".equals(arg0.getPath())) {
-          return new MockResponse().setResponseCode(200)
-              .setHeaders(Headers.of("Content-Type", "application/fhir+json"))
-              .setBody(metadata);
-        } else {
-          return new MockResponse().setResponseCode(404);
+                @Override
+                public MockResponse dispatch(RecordedRequest arg0) throws InterruptedException {
+                    if ("/metadata".equals(arg0.getPath())) {
+                        return new MockResponse().setResponseCode(200)
+                                .setHeaders(Headers.of("Content-Type", "application/fhir+json"))
+                                .setBody(metadata);
+                    } else {
+                        return new MockResponse().setResponseCode(404);
+                    }
+                    }
+            });
+            directSpringConfig = new DirectSpringConfig(true, null,
+                    String.format("http://localhost:%s", mockWebServer.getPort()), null, null,
+                    String.format("http://localhost:%s/realms/test", keycloak.getFirstMappedPort()), "account", "test",
+                    Duration.ofSeconds(10), false);
+            IGenericClient client = directSpringConfig.getFhirClient(FhirContext.forR4());
+
+            client.capabilities().ofType(CapabilityStatement.class).execute();
+
+            var recordedRequest = mockWebServer.takeRequest();
+            assertThat(recordedRequest.getHeader(HttpHeaders.AUTHORIZATION)).startsWith("Bearer ey");
+        } finally {
+            keycloak.stop();
         }
-      }
-    });
-    directSpringConfig = new DirectSpringConfig(true, null,
-        String.format("http://localhost:%s", mockWebServer.getPort()), null, null,
-            String.format("http://localhost:%s/realms/test", keycloak.getFirstMappedPort()), "account", "test",
-            Duration.ofSeconds(10));
-    IGenericClient client = directSpringConfig.getFhirClient(FhirContext.forR4());
+    }
 
-    client.capabilities().ofType(CapabilityStatement.class).execute();
+    @Test
+    @DisplayName("flare webClient succeeds getting 1s delayed response before timeout of 5s")
+    void flareClientSucceedsFinishingBeforeTimeout() throws Exception {
+        var timeout = Duration.ofSeconds(5);
+        var body = "Foo";
+        mockWebServer.enqueue(new MockResponse().setResponseCode(200).setBody(body).setBodyDelay(1, SECONDS));
+        directSpringConfig = new DirectSpringConfig(false,
+                String.format("http://localhost:%s", mockWebServer.getPort()),
+                null, null, null, null, null, null, timeout, false);
+        var client = directSpringConfig.directWebClientFlare();
 
-    var recordedRequest = mockWebServer.takeRequest();
-    assertThat(recordedRequest.getHeader(HttpHeaders.AUTHORIZATION)).startsWith("Bearer ey");
-  }
+        Instant start = Instant.now();
+        var response = client.get()
+                .uri("/foo")
+                .retrieve()
+                .bodyToMono(String.class)
+                .block();
 
-  @Test
-  @DisplayName("flare webClient succeeds getting 1s delayed response before timeout of 5s")
-  void flareClientSucceedsFinishingBeforeTimeout() throws Exception {
-      var timeout = Duration.ofSeconds(5);
-      var body = "Foo";
-      mockWebServer.enqueue(new MockResponse().setResponseCode(200).setBody(body).setBodyDelay(1, SECONDS));
-      directSpringConfig = new DirectSpringConfig(false, String.format("http://localhost:%s", mockWebServer.getPort()),
-              null, null, null, null, null, null, timeout);
-      var client = directSpringConfig.directWebClientFlare();
+        assertThat(response).isEqualTo(body);
+        assertThat(Duration.between(start, Instant.now())).isLessThan(timeout);
+    }
 
-      Instant start = Instant.now();
-      var response = client.get()
-              .uri("/foo")
-              .retrieve()
-              .bodyToMono(String.class)
-              .block();
+    @Test
+    @DisplayName("flare webClient fails not getting 5s delayed response before given timeout of 2s")
+    void flareClientFailsReachingTimeout() throws Exception {
+        var timeout = Duration.ofSeconds(2);
+        var delta = Duration.ofSeconds(1);
+        var delay = 5;
+        mockWebServer.enqueue(new MockResponse().setResponseCode(200).setBody("Foo").setBodyDelay(delay, SECONDS));
+        directSpringConfig = new DirectSpringConfig(false,
+                String.format("http://localhost:%s", mockWebServer.getPort()),
+                null, null, null, null, null, null, timeout, false);
+        var client = directSpringConfig.directWebClientFlare();
 
-      assertThat(response).isEqualTo(body);
-      assertThat(Duration.between(start, Instant.now())).isLessThan(timeout);
-  }
+        Instant start = Instant.now();
+        assertThatThrownBy(() -> client.get()
+                .uri("/foo")
+                .retrieve()
+                .bodyToMono(String.class)
+                .block()).isInstanceOf(WebClientResponseException.class)
+                        .hasCauseInstanceOf(ReadTimeoutException.class);
+        var elapsed = Duration.between(start, Instant.now());
+        assertThat(elapsed).isBetween(timeout, timeout.plus(delta));
+        Thread.sleep(Duration.ofSeconds(delay).minus(elapsed).toMillis());
+    }
 
-  @Test
-  @DisplayName("flare webClient fails not getting 5s delayed response before given timeout of 2s")
-  void flareClientFailsReachingTimeout() throws Exception {
-      var timeout = Duration.ofSeconds(2);
-      var delta = Duration.ofSeconds(1);
-      var delay = 5;
-      mockWebServer.enqueue(new MockResponse().setResponseCode(200).setBody("Foo").setBodyDelay(delay, SECONDS));
-      directSpringConfig = new DirectSpringConfig(false, String.format("http://localhost:%s", mockWebServer.getPort()),
-              null, null, null, null, null, null, timeout);
-      var client = directSpringConfig.directWebClientFlare();
+    @Test
+    @DisplayName("FHIR client succeeds getting 1s delayed response before given timeout of 5s")
+    void fhirClientSucceedsFinishingBeforeTimeout() throws Exception {
+        var metadata = new ClassPathResource("fhir-metadata.json", DirectSpringConfigIT.class)
+                .getContentAsString(Charsets.UTF_8);
+        var timeout = Duration.ofSeconds(5);
+        var delta = Duration.ofSeconds(1);
+        var delay = 1;
+        var response = new MockResponse().setResponseCode(200)
+                .setHeaders(Headers.of("Content-Type", "application/fhir+json"))
+                .setBody(metadata);
+        mockWebServer.enqueue(response);
+        mockWebServer.enqueue(response.clone()
+                .setBodyDelay(delay, SECONDS));
+        directSpringConfig = new DirectSpringConfig(true, null,
+                String.format("http://localhost:%s", mockWebServer.getPort()), null, null, null, null, null, timeout,
+                false);
+        var client = directSpringConfig.getFhirClient(FhirContext.forR4());
 
-      Instant start = Instant.now();
-      assertThatThrownBy(() -> client.get()
-              .uri("/foo")
-              .retrieve()
-              .bodyToMono(String.class)
-              .block()).isInstanceOf(WebClientResponseException.class)
-                      .hasCauseInstanceOf(ReadTimeoutException.class);
-      var elapsed = Duration.between(start, Instant.now());
-      assertThat(elapsed).isBetween(timeout, timeout.plus(delta));
-      Thread.sleep(Duration.ofSeconds(delay).minus(elapsed).toMillis());
-  }
+        Instant start = Instant.now();
+        client.capabilities().ofType(CapabilityStatement.class).execute();
 
-  @Test
-  @DisplayName("FHIR client succeeds getting 1s delayed response before given timeout of 5s")
-  void fhirClientSucceedsFinishingBeforeTimeout() throws Exception {
-      var metadata = new ClassPathResource("fhir-metadata.json", DirectSpringConfigIT.class)
-              .getContentAsString(Charsets.UTF_8);
-      var timeout = Duration.ofSeconds(5);
-      var delta = Duration.ofSeconds(1);
-      var delay = 1;
-      var response = new MockResponse().setResponseCode(200)
-              .setHeaders(Headers.of("Content-Type", "application/fhir+json"))
-              .setBody(metadata);
-      mockWebServer.enqueue(response);
-      mockWebServer.enqueue(response.clone()
-              .setBodyDelay(delay, SECONDS));
-      directSpringConfig = new DirectSpringConfig(true, null,
-              String.format("http://localhost:%s", mockWebServer.getPort()), null, null, null, null, null, timeout);
-      var client = directSpringConfig.getFhirClient(FhirContext.forR4());
+        assertThat(Duration.between(start, Instant.now())).isLessThan(timeout.plus(delta));
+        assertThat(mockWebServer.getRequestCount()).isEqualTo(2);
+        assertThat(mockWebServer.takeRequest().getPath())
+                .isEqualTo(mockWebServer.takeRequest().getPath())
+                .isEqualTo("/metadata");
+    }
 
-      Instant start = Instant.now();
-      client.capabilities().ofType(CapabilityStatement.class).execute();
+    @Test
+    @DisplayName("FHIR client fails not getting 5s delayed response before given timeout of 2s")
+    void fhirClientFailsReachingTimeout() throws Exception {
+        var metadata = new ClassPathResource("fhir-metadata.json", DirectSpringConfigIT.class)
+                .getContentAsString(Charsets.UTF_8);
+        var timeout = Duration.ofSeconds(2);
+        var delta = Duration.ofSeconds(1);
+        var delay = 5;
+        var response = new MockResponse().setResponseCode(200)
+                .setHeaders(Headers.of("Content-Type", "application/fhir+json"))
+                .setBody(metadata);
+        mockWebServer.enqueue(response);
+        mockWebServer.enqueue(response.clone()
+                .setBodyDelay(delay, SECONDS));
+        directSpringConfig = new DirectSpringConfig(true, null,
+                String.format("http://localhost:%s", mockWebServer.getPort()), null, null, null, null, null, timeout,
+                false);
+        var client = directSpringConfig.getFhirClient(FhirContext.forR4());
 
-      assertThat(Duration.between(start, Instant.now())).isLessThan(timeout.plus(delta));
-      assertThat(mockWebServer.getRequestCount()).isEqualTo(2);
-      assertThat(mockWebServer.takeRequest().getPath())
-              .isEqualTo(mockWebServer.takeRequest().getPath())
-              .isEqualTo("/metadata");
-  }
+        Instant start = Instant.now();
+        assertThatThrownBy(() -> client.capabilities().ofType(CapabilityStatement.class).execute())
+                .isInstanceOf(FhirClientConnectionException.class);
+        var elapsed = Duration.between(start, Instant.now());
+        assertThat(elapsed).isBetween(timeout, timeout.plus(delta));
+        assertThat(mockWebServer.getRequestCount()).isEqualTo(2);
+        assertThat(mockWebServer.takeRequest().getPath())
+                .isEqualTo(mockWebServer.takeRequest().getPath())
+                .isEqualTo("/metadata");
+        Thread.sleep(Duration.ofSeconds(delay).minus(elapsed).toMillis());
+    }
 
-  @Test
-  @DisplayName("FHIR client fails not getting 5s delayed response before given timeout of 2s")
-  @Disabled("This test frequently fails when run via github actions. Locally, it runs without trouble. Further investigation recommended.")
-  void fhirClientFailsReachingTimeout() throws Exception {
-      var metadata = new ClassPathResource("fhir-metadata.json", DirectSpringConfigIT.class)
-              .getContentAsString(Charsets.UTF_8);
-      var timeout = Duration.ofSeconds(2);
-      var delta = Duration.ofSeconds(1);
-      var delay = 5;
-      var response = new MockResponse().setResponseCode(200)
-              .setHeaders(Headers.of("Content-Type", "application/fhir+json"))
-              .setBody(metadata);
-      mockWebServer.enqueue(response);
-      mockWebServer.enqueue(response.clone()
-              .setBodyDelay(delay, SECONDS));
-      directSpringConfig = new DirectSpringConfig(true, null,
-              String.format("http://localhost:%s", mockWebServer.getPort()), null, null, null, null, null, timeout);
-      var client = directSpringConfig.getFhirClient(FhirContext.forR4());
+    @Test
+    @DisplayName("FHIR client uses Async Interaction Request Pattern successfully")
+    void asyncFhirClientSucceeds() throws Exception {
+        var metadata = new ClassPathResource("fhir-metadata.json", DirectSpringConfigIT.class)
+                .getContentAsString(Charsets.UTF_8);
+        var statusPath = "/Measure/foo/bar/status";
+        var body = "bar";
+        var metadataResponse = new MockResponse().setResponseCode(200)
+                .setHeaders(Headers.of("Content-Type", "application/fhir+json"))
+                .setBody(metadata);
+        var kickOffResponse = new MockResponse().setResponseCode(202)
+                .setHeaders(Headers.of("Content-Location",
+                        "http://localhost:%s%s".formatted(mockWebServer.getPort(), statusPath)))
+                .setBody("");
+        var inProgressResponse = new MockResponse().setResponseCode(202)
+                .setHeaders(Headers.of("X-Progress", "0%"))
+                .setBody("");
+        var finalResponse = new MockResponse().setResponseCode(200)
+                .setHeaders(Headers.of("Content-Type", "text/plain"))
+                .setBody(body);
+        mockWebServer.enqueue(metadataResponse);
+        mockWebServer.enqueue(kickOffResponse);
+        mockWebServer.enqueue(inProgressResponse);
+        mockWebServer.enqueue(inProgressResponse);
+        mockWebServer.enqueue(finalResponse);
+        directSpringConfig = new DirectSpringConfig(true, null,
+                "http://localhost:%s".formatted(mockWebServer.getPort()), null, null, null, null, null,
+                Duration.ofSeconds(10), true);
+        var client = directSpringConfig.getFhirClient(FhirContext.forR4());
 
-      Instant start = Instant.now();
-      assertThatThrownBy(() -> client.capabilities().ofType(CapabilityStatement.class).execute())
-              .isInstanceOf(FhirClientConnectionException.class);
-      var elapsed = Duration.between(start, Instant.now());
-      assertThat(elapsed).isBetween(timeout, timeout.plus(delta));
-      assertThat(mockWebServer.getRequestCount()).isEqualTo(2);
-      assertThat(mockWebServer.takeRequest().getPath())
-              .isEqualTo(mockWebServer.takeRequest().getPath())
-              .isEqualTo("/metadata");
-      Thread.sleep(Duration.ofSeconds(delay).minus(elapsed).toMillis());
-  }
+        var result = client.operation().onInstance("Measure/foo").named("bar").withNoParameters(Parameters.class)
+                .returnResourceType(Binary.class).execute();
+
+        assertThat(mockWebServer.getRequestCount()).isEqualTo(5);
+        assertThat(mockWebServer.takeRequest())
+                .returns("/metadata", from(r -> r.getPath()))
+                .returns("respond-async", from(r -> r.getHeader("Prefer")));
+        assertThat(mockWebServer.takeRequest())
+                .matches(r -> "/Measure/foo/$bar".equals(r.getPath()), "path is '/Measure/foo/$bar'");
+        assertThat(mockWebServer.takeRequest())
+                .matches(r -> statusPath.equals(r.getPath()), "path is '%s'".formatted(statusPath));
+        assertThat(mockWebServer.takeRequest())
+                .matches(r -> statusPath.equals(r.getPath()), "path is '%s'".formatted(statusPath));
+        assertThat(mockWebServer.takeRequest())
+                .matches(r -> statusPath.equals(r.getPath()), "path is '%s'".formatted(statusPath));
+        assertThat(new String(result.getContent())).isEqualTo(body);
+    }
+
+    @Test
+    @DisplayName("Async FHIR client fails when kickoff response contains no Content-Location header")
+    void asyncFhirClientFailsWithNoContentLocation() throws Exception {
+        var metadata = new ClassPathResource("fhir-metadata.json", DirectSpringConfigIT.class)
+                .getContentAsString(Charsets.UTF_8);
+        var metadataResponse = new MockResponse().setResponseCode(200)
+                .setHeaders(Headers.of("Content-Type", "application/fhir+json"))
+                .setBody(metadata);
+        var kickOffResponse = new MockResponse().setResponseCode(202)
+                .setBody("");
+        mockWebServer.enqueue(metadataResponse);
+        mockWebServer.enqueue(kickOffResponse);
+        directSpringConfig = new DirectSpringConfig(true, null,
+                "http://localhost:%s".formatted(mockWebServer.getPort()), null, null, null, null, null,
+                Duration.ofSeconds(10), true);
+        var client = directSpringConfig.getFhirClient(FhirContext.forR4());
+
+        assertThatThrownBy(
+                () -> client.operation().onInstance("Measure/foo").named("bar").withNoParameters(Parameters.class)
+                        .returnResourceType(Binary.class).execute())
+                                .hasCauseInstanceOf(AsyncRequestException.class)
+                                .cause().hasMessageContaining("No Content-Location provided for polling");
+
+        assertThat(mockWebServer.getRequestCount()).isEqualTo(2);
+        assertThat(mockWebServer.takeRequest())
+                .returns("/metadata", from(r -> r.getPath()))
+                .returns("respond-async", from(r -> r.getHeader("Prefer")));
+        assertThat(mockWebServer.takeRequest())
+                .matches(r -> "/Measure/foo/$bar".equals(r.getPath()), "path is '/Measure/foo/$bar'");
+    }
+
+    @Test
+    @DisplayName("Async FHIR client respects the Retry-After header of server response")
+    void asyncFhirClientRespectsRetryAfterHeader() throws Exception {
+        var metadata = new ClassPathResource("fhir-metadata.json", DirectSpringConfigIT.class)
+                .getContentAsString(Charsets.UTF_8);
+        var statusPath = "/Measure/foo/bar/status";
+        var body = "bar";
+        var start = Instant.now();
+        var metadataResponse = new MockResponse().setResponseCode(200)
+                .setHeaders(Headers.of("Content-Type", "application/fhir+json"))
+                .setBody(metadata);
+        var kickOffResponse = new MockResponse().setResponseCode(202)
+                .setHeaders(Headers.of("Content-Location",
+                        "http://localhost:%s%s".formatted(mockWebServer.getPort(), statusPath)))
+                .setBody("");
+        // Use HTTP date format as Retry-After header value
+        var inProgressResponse1 = new MockResponse().setResponseCode(202)
+                .setHeaders(Headers.of(HttpHeaders.RETRY_AFTER,
+                        DateTimeFormatter.RFC_1123_DATE_TIME.withZone(ZoneId.of("GMT"))
+                                .withLocale(Locale.US)
+                                .format(Instant.now().plus(Duration.ofSeconds(5)))))
+                .setBody("");
+        // Use integer value as Retra-After header value representing seconds
+        var inProgressResponse2 = new MockResponse().setResponseCode(202)
+                .setHeaders(Headers.of(HttpHeaders.RETRY_AFTER, "3"))
+                .setBody("");
+        var finalResponse = new MockResponse().setResponseCode(200)
+                .setHeaders(Headers.of("Content-Type", "text/plain"))
+                .setBody(body);
+        mockWebServer.enqueue(metadataResponse);
+        mockWebServer.enqueue(kickOffResponse);
+        mockWebServer.enqueue(inProgressResponse1);
+        mockWebServer.enqueue(inProgressResponse2);
+        mockWebServer.enqueue(finalResponse);
+        directSpringConfig = new DirectSpringConfig(true, null,
+                "http://localhost:%s".formatted(mockWebServer.getPort()), null, null, null, null, null,
+                Duration.ofSeconds(20), true);
+        var client = directSpringConfig.getFhirClient(FhirContext.forR4());
+
+        var result = client.operation().onInstance("Measure/foo").named("bar").withNoParameters(Parameters.class)
+                .returnResourceType(Binary.class).execute();
+
+        assertThat(Duration.between(start, Instant.now()))
+                .isGreaterThan(Duration.ofSeconds(5));
+        assertThat(mockWebServer.getRequestCount()).isEqualTo(5);
+        assertThat(mockWebServer.takeRequest())
+                .returns("/metadata", from(r -> r.getPath()))
+                .returns("respond-async", from(r -> r.getHeader("Prefer")));
+        assertThat(mockWebServer.takeRequest())
+                .matches(r -> "/Measure/foo/$bar".equals(r.getPath()), "path is '/Measure/foo/$bar'");
+        assertThat(mockWebServer.takeRequest())
+                .matches(r -> statusPath.equals(r.getPath()), "path is '%s'".formatted(statusPath));
+        assertThat(mockWebServer.takeRequest())
+                .matches(r -> statusPath.equals(r.getPath()), "path is '%s'".formatted(statusPath));
+        assertThat(mockWebServer.takeRequest())
+                .matches(r -> statusPath.equals(r.getPath()), "path is '%s'".formatted(statusPath));
+        assertThat(new String(result.getContent())).isEqualTo(body);
+    }
+
+    @Test
+    @DisplayName("Async FHIR client uses predefined exponential timeout on invalid Retry-After header value")
+    void asyncFhirClientIgnoresInvalidRetryAfterHeader(CapturedOutput output) throws Exception {
+        var metadata = new ClassPathResource("fhir-metadata.json", DirectSpringConfigIT.class)
+                .getContentAsString(Charsets.UTF_8);
+        var statusPath = "/Measure/foo/bar/status";
+        var body = "bar";
+        var start = Instant.now();
+        var metadataResponse = new MockResponse().setResponseCode(200)
+                .setHeaders(Headers.of("Content-Type", "application/fhir+json"))
+                .setBody(metadata);
+        var kickOffResponse = new MockResponse().setResponseCode(202)
+                .setHeaders(Headers.of("Content-Location",
+                        "http://localhost:%s%s".formatted(mockWebServer.getPort(), statusPath)))
+                .setBody("");
+        var inProgressResponse = new MockResponse().setResponseCode(202)
+                .setHeaders(Headers.of(HttpHeaders.RETRY_AFTER, "five seconds"))
+                .setBody("");
+        var finalResponse = new MockResponse().setResponseCode(200)
+                .setHeaders(Headers.of("Content-Type", "text/plain"))
+                .setBody(body);
+        mockWebServer.enqueue(metadataResponse);
+        mockWebServer.enqueue(kickOffResponse);
+        mockWebServer.enqueue(inProgressResponse); // 250ms wait time
+        mockWebServer.enqueue(inProgressResponse); // 500ms wait time
+        mockWebServer.enqueue(inProgressResponse); // 1000ms wait time
+        mockWebServer.enqueue(finalResponse);
+        directSpringConfig = new DirectSpringConfig(true, null,
+                "http://localhost:%s".formatted(mockWebServer.getPort()), null, null, null, null, null,
+                Duration.ofSeconds(20), true);
+        var client = directSpringConfig.getFhirClient(FhirContext.forR4());
+
+        var result = client.operation().onInstance("Measure/foo").named("bar").withNoParameters(Parameters.class)
+                .returnResourceType(Binary.class).execute();
+
+        assertThat(Duration.between(start, Instant.now()))
+                .isGreaterThan(Duration.ofMillis(1750));
+        assertThat(mockWebServer.getRequestCount()).isEqualTo(6);
+        assertThat(mockWebServer.takeRequest())
+                .returns("/metadata", from(r -> r.getPath()))
+                .returns("respond-async", from(r -> r.getHeader("Prefer")));
+        assertThat(mockWebServer.takeRequest())
+                .matches(r -> "/Measure/foo/$bar".equals(r.getPath()), "path is '/Measure/foo/$bar'");
+        assertThat(mockWebServer.takeRequest())
+                .matches(r -> statusPath.equals(r.getPath()), "path is '%s'".formatted(statusPath));
+        assertThat(mockWebServer.takeRequest())
+                .matches(r -> statusPath.equals(r.getPath()), "path is '%s'".formatted(statusPath));
+        assertThat(new String(result.getContent())).isEqualTo(body);
+        assertThat(output.getOut()).contains("invalid Retry-After header value: five seconds");
+    }
+
+    @Test
+    @DisplayName("Async FHIR client sends DELETE request to status location after polling exceeded client timeout")
+    void asyncFhirClientSendsDeleteRequestAfterTimeout() throws Exception {
+        var metadata = new ClassPathResource("fhir-metadata.json", DirectSpringConfigIT.class)
+                .getContentAsString(Charsets.UTF_8);
+        var statusPath = "/Measure/foo/bar/status";
+        var body = "bar";
+        var metadataResponse = new MockResponse().setResponseCode(200)
+                .setHeaders(Headers.of("Content-Type", "application/fhir+json"))
+                .setBody(metadata);
+        var kickOffResponse = new MockResponse().setResponseCode(202)
+                .setHeaders(Headers.of("Content-Location",
+                        "http://localhost:%s%s".formatted(mockWebServer.getPort(), statusPath)))
+                .setBody("");
+        var inProgressResponse = new MockResponse().setResponseCode(202)
+                .setHeaders(Headers.of("X-Progress", "0%"))
+                .setHeadersDelay(1, SECONDS)
+                .setBody("");
+        var deleteResponse = new MockResponse().setResponseCode(202)
+                .setHeaders(Headers.of("Content-Type", "text/plain"))
+                .setBody(body);
+        mockWebServer.enqueue(metadataResponse);
+        mockWebServer.enqueue(kickOffResponse);
+        mockWebServer.enqueue(inProgressResponse);
+        mockWebServer.enqueue(inProgressResponse);
+        mockWebServer.enqueue(deleteResponse);
+        directSpringConfig = new DirectSpringConfig(true, null,
+                "http://localhost:%s".formatted(mockWebServer.getPort()), null, null, null, null, null,
+                Duration.ofSeconds(2), true);
+        var client = directSpringConfig.getFhirClient(FhirContext.forR4());
+        var result = client.operation().onInstance("Measure/foo").named("bar").withNoParameters(Parameters.class)
+                .returnResourceType(Binary.class).execute();
+
+        assertThat(result).matches(b -> b.hasData())
+                .extracting(b -> new String(b.getData()))
+                .asString()
+                .isEqualTo(body);
+        assertThat(mockWebServer.getRequestCount()).isEqualTo(5);
+        assertThat(mockWebServer.takeRequest())
+                .returns("/metadata", from(r -> r.getPath()))
+                .returns("respond-async", from(r -> r.getHeader("Prefer")));
+        assertThat(mockWebServer.takeRequest())
+                .matches(r -> "/Measure/foo/$bar".equals(r.getPath()), "path is '/Measure/foo/$bar'");
+        assertThat(mockWebServer.takeRequest())
+                .matches(r -> statusPath.equals(r.getPath()), "path is '%s'".formatted(statusPath));
+        assertThat(mockWebServer.takeRequest())
+                .matches(r -> statusPath.equals(r.getPath()), "path is '%s'".formatted(statusPath));
+        assertThat(mockWebServer.takeRequest())
+                .matches(r -> statusPath.equals(r.getPath()), "path is '%s'".formatted(statusPath))
+                .matches(r -> r.getMethod().equals(HttpMethod.DELETE.name()),
+                        "http method is '%s'".formatted(HttpMethod.DELETE.name()));
+    }
+
+    @Test
+    @DisplayName("Async FHIR client handles thread interruption during polling")
+    void asyncFhirClientHandlesInterruption() throws Exception {
+        var metadata = new ClassPathResource("fhir-metadata.json", DirectSpringConfigIT.class)
+                .getContentAsString(Charsets.UTF_8);
+        var statusPath = "/Measure/foo/bar/status";
+        var body = "interrupted-response";
+        var metadataResponse = new MockResponse().setResponseCode(200)
+                .setHeaders(Headers.of("Content-Type", "application/fhir+json"))
+                .setBody(metadata);
+        var kickOffResponse = new MockResponse().setResponseCode(202)
+                .setHeaders(Headers.of("Content-Location",
+                        "http://localhost:%s%s".formatted(mockWebServer.getPort(), statusPath)))
+                .setBody("");
+        // Long delay to ensure we're in sleep when interruption happens
+        var inProgressResponse = new MockResponse().setResponseCode(202)
+                .setHeaders(Headers.of(HttpHeaders.RETRY_AFTER, "5"))
+                .setBody("");
+        var deleteResponse = new MockResponse().setResponseCode(202)
+                .setHeaders(Headers.of("Content-Type", "text/plain"))
+                .setBody(body);
+        mockWebServer.enqueue(metadataResponse);
+        mockWebServer.enqueue(kickOffResponse);
+        mockWebServer.enqueue(inProgressResponse);
+        mockWebServer.enqueue(deleteResponse);
+        directSpringConfig = new DirectSpringConfig(true, null,
+                "http://localhost:%s".formatted(mockWebServer.getPort()), null, null, null, null, null,
+                Duration.ofSeconds(10), true);
+        var client = directSpringConfig.getFhirClient(FhirContext.forR4());
+
+        // Create a second thread to execute the operation and interrupt it during polling
+        Thread operationThread = new Thread(() -> {
+            try {
+                client.operation().onInstance("Measure/foo").named("bar").withNoParameters(Parameters.class)
+                        .returnResourceType(Binary.class).execute();
+            } catch (Exception e) {
+                // Expect exception due to interruption
+            }
+        });
+
+        // Start the operation and wait briefly to ensure it's in polling phase
+        operationThread.start();
+        Thread.sleep(500); // Wait for operation to start polling
+
+        // Interrupt the thread during polling
+        operationThread.interrupt();
+        operationThread.join(); // Wait for thread to complete
+
+        // Verify that DELETE request was sent
+        assertThat(mockWebServer.getRequestCount()).isEqualTo(4);
+        mockWebServer.takeRequest(); // Skip metadata request
+        mockWebServer.takeRequest(); // Skip initial operation request
+        mockWebServer.takeRequest(); // Skip first polling request
+
+        // Verify the last request was a DELETE to the status endpoint
+        RecordedRequest lastRequest = mockWebServer.takeRequest();
+        assertThat(lastRequest)
+                .matches(r -> statusPath.equals(r.getPath()), "path is '%s'".formatted(statusPath))
+                .matches(r -> r.getMethod().equals(HttpMethod.DELETE.name()),
+                        "http method is '%s'".formatted(HttpMethod.DELETE.name()));
+    }
+
+    @Test
+    @DisplayName("Async FHIR client handles non-202 response when canceling request")
+    void asyncFhirClientHandlesNon202ResponseWhenCanceling(CapturedOutput output) throws Exception {
+        var metadata = new ClassPathResource("fhir-metadata.json", DirectSpringConfigIT.class)
+                .getContentAsString(Charsets.UTF_8);
+        var statusPath = "/Measure/foo/bar/status";
+        var metadataResponse = new MockResponse().setResponseCode(200)
+                .setHeaders(Headers.of("Content-Type", "application/fhir+json"))
+                .setBody(metadata);
+        var kickOffResponse = new MockResponse().setResponseCode(202)
+                .setHeaders(Headers.of("Content-Location",
+                        "http://localhost:%s%s".formatted(mockWebServer.getPort(), statusPath)))
+                .setBody("");
+        var inProgressResponse = new MockResponse().setResponseCode(202)
+                .setHeaders(Headers.of(HttpHeaders.RETRY_AFTER, "5"))
+                .setBody("");
+        // Server returns 404 Not Found when trying to cancel the request
+        var deleteResponse = new MockResponse().setResponseCode(404)
+                .setHeaders(Headers.of("Content-Type", "text/plain"))
+                .setBody("Not Found");
+        mockWebServer.enqueue(metadataResponse);
+        mockWebServer.enqueue(kickOffResponse);
+        mockWebServer.enqueue(inProgressResponse);
+        mockWebServer.enqueue(deleteResponse);
+        directSpringConfig = new DirectSpringConfig(true, null,
+                "http://localhost:%s".formatted(mockWebServer.getPort()), null, null, null, null, null,
+                Duration.ofSeconds(1), true); // Short timeout to trigger cancellation
+        var client = directSpringConfig.getFhirClient(FhirContext.forR4());
+
+        // This should complete normally but log an error about failing to cancel
+        assertThatThrownBy(
+                () -> client.operation().onInstance("Measure/foo").named("bar").withNoParameters(Parameters.class)
+                        .returnResourceType(Binary.class).execute())
+                                .isInstanceOf(BaseServerResponseException.class);
+
+        // Verify that DELETE request was sent
+        assertThat(mockWebServer.getRequestCount()).isEqualTo(4);
+        mockWebServer.takeRequest(); // Skip metadata request
+        mockWebServer.takeRequest(); // Skip initial operation request
+        mockWebServer.takeRequest(); // Skip first polling request
+
+        // Verify the last request was a DELETE to the status endpoint
+        var lastRequest = mockWebServer.takeRequest();
+        assertThat(lastRequest)
+                .matches(r -> statusPath.equals(r.getPath()), "path is '%s'".formatted(statusPath))
+                .matches(r -> r.getMethod().equals(HttpMethod.DELETE.name()),
+                        "http method is '%s'".formatted(HttpMethod.DELETE.name()));
+        assertThat(output.getOut()).contains("Got http status 404 cancelling asynchronous request");
+    }
+
+    @Test
+    @DisplayName("Async FHIR client handles HttpException when canceling request")
+    void asyncFhirClientHandlesHttpExceptionWhenCanceling() throws Exception {
+        var metadata = new ClassPathResource("fhir-metadata.json", DirectSpringConfigIT.class)
+                .getContentAsString(Charsets.UTF_8);
+        var statusPath = "/Measure/foo/bar/status";
+        var metadataResponse = new MockResponse().setResponseCode(200)
+                .setHeaders(Headers.of("Content-Type", "application/fhir+json"))
+                .setBody(metadata);
+        var kickOffResponse = new MockResponse().setResponseCode(202)
+                .setHeaders(Headers.of("Content-Location",
+                        "http://localhost:%s%s".formatted(mockWebServer.getPort(), statusPath)))
+                .setBody("");
+        var inProgressResponse = new MockResponse().setResponseCode(202)
+                .setHeaders(Headers.of(HttpHeaders.RETRY_AFTER, "5"))
+                .setBody("");
+        // send invalid http status code
+        var cancelResponse = new MockResponse().setResponseCode(42)
+                .setBody("");
+
+        mockWebServer.enqueue(metadataResponse);
+        mockWebServer.enqueue(kickOffResponse);
+        mockWebServer.enqueue(inProgressResponse);
+        mockWebServer.enqueue(cancelResponse);
+
+        directSpringConfig = new DirectSpringConfig(true, null,
+                "http://localhost:%s".formatted(mockWebServer.getPort()), null, null, null, null, null,
+                Duration.ofSeconds(1), true); // Short timeout to trigger cancellation
+        var client = directSpringConfig.getFhirClient(FhirContext.forR4());
+
+        assertThatThrownBy(
+                () -> client.operation().onInstance("Measure/foo").named("bar").withNoParameters(Parameters.class)
+                        .returnResourceType(Binary.class).execute())
+                                .hasCauseInstanceOf(AsyncRequestException.class)
+                                .cause().hasMessageContaining("Failed to cancel asynchronous request at");
+    }
+
 }

--- a/src/test/java/de/numcodex/feasibility_gui_backend/query/broker/direct/DirectSpringConfigTest.java
+++ b/src/test/java/de/numcodex/feasibility_gui_backend/query/broker/direct/DirectSpringConfigTest.java
@@ -46,7 +46,7 @@ class DirectSpringConfigTest {
   @Test
   void directWebClientFlare_withCredentials() {
     directSpringConfig = new DirectSpringConfig(true, "http://my.flare.url", null, "username", "password", null, null,
-            null, TIMEOUT);
+            null, TIMEOUT, false);
 
     WebClient webClient = directSpringConfig.directWebClientFlare();
 
@@ -57,7 +57,7 @@ class DirectSpringConfigTest {
   @Test
   void directWebClientFlare_withoutCredentials() {
       directSpringConfig = new DirectSpringConfig(true, "http://my.flare.url", null, null, null, null, null, null,
-              TIMEOUT);
+              TIMEOUT, false);
 
     WebClient webClient = directSpringConfig.directWebClientFlare();
 
@@ -68,7 +68,7 @@ class DirectSpringConfigTest {
   @Test
   void getFhirClient_withCredentials() {
     directSpringConfig = new DirectSpringConfig(true, null, "http://my.fhir.url", "username", "password", null, null,
-            null, TIMEOUT);
+            null, TIMEOUT, false);
 
     IGenericClient fhirClient = directSpringConfig.getFhirClient(fhirContext);
 
@@ -80,7 +80,7 @@ class DirectSpringConfigTest {
   @Test
   void getFhirClient_withoutCredentials() {
       directSpringConfig = new DirectSpringConfig(true, null, "http://my.fhir.url", null, null, null, null, null,
-              TIMEOUT);
+              TIMEOUT, false);
 
     IGenericClient fhirClient = directSpringConfig.getFhirClient(fhirContext);
 
@@ -92,7 +92,7 @@ class DirectSpringConfigTest {
   @Test
   void directBrokerClient_withOAuthCredentials() {
     directSpringConfig = new DirectSpringConfig(true, null, "http://my.fhir.url", null, null, "http://my.oauth.url",
-            "foo", "bar", TIMEOUT);
+            "foo", "bar", TIMEOUT, false);
 
     IGenericClient fhirClient = directSpringConfig.getFhirClient(fhirContext);
 
@@ -103,7 +103,7 @@ class DirectSpringConfigTest {
 
   @Test
   void directBrokerClient_useCql() {
-      directSpringConfig = new DirectSpringConfig(true, null, null, null, null, null, null, null, TIMEOUT);
+      directSpringConfig = new DirectSpringConfig(true, null, null, null, null, null, null, null, TIMEOUT, false);
 
     BrokerClient brokerClient = directSpringConfig.directBrokerClient(webClient, false, fhirConnector, fhirHelper);
 
@@ -112,7 +112,7 @@ class DirectSpringConfigTest {
 
   @Test
   void directBrokerClient_useFlare() {
-      directSpringConfig = new DirectSpringConfig(false, null, null, null, null, null, null, null, TIMEOUT);
+      directSpringConfig = new DirectSpringConfig(false, null, null, null, null, null, null, null, TIMEOUT, false);
 
     BrokerClient brokerClient = directSpringConfig.directBrokerClient(webClient, false, fhirConnector, fhirHelper);
 
@@ -122,7 +122,7 @@ class DirectSpringConfigTest {
   @Test
   void fhirClient_withTimeout() {
       directSpringConfig = new DirectSpringConfig(true, null, "http://my.fhir.url", null, null, null, null, null,
-              TIMEOUT);
+              TIMEOUT, false);
 
       var fhirClient = directSpringConfig.getFhirClient(fhirContext);
 

--- a/src/test/java/de/numcodex/feasibility_gui_backend/query/broker/direct/FhirConnectorTest.java
+++ b/src/test/java/de/numcodex/feasibility_gui_backend/query/broker/direct/FhirConnectorTest.java
@@ -1,27 +1,40 @@
 package de.numcodex.feasibility_gui_backend.query.broker.direct;
 
-import static org.junit.jupiter.api.Assertions.assertThrows;
 import ca.uhn.fhir.rest.client.api.IGenericClient;
-import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.mockito.Mockito.verify;
-
+import ca.uhn.fhir.rest.gclient.IOperationUntypedWithInput;
 import ca.uhn.fhir.rest.param.DateParam;
 import ca.uhn.fhir.rest.param.StringParam;
 import ca.uhn.fhir.rest.server.exceptions.BaseServerResponseException;
-import java.io.IOException;
 import org.hl7.fhir.r4.model.Bundle;
+import org.hl7.fhir.r4.model.CapabilityStatement;
+import org.hl7.fhir.r4.model.CapabilityStatement.CapabilityStatementSoftwareComponent;
 import org.hl7.fhir.r4.model.Measure;
 import org.hl7.fhir.r4.model.MeasureReport;
+import org.hl7.fhir.r4.model.OperationOutcome;
 import org.hl7.fhir.r4.model.Parameters;
+import org.hl7.fhir.r4.model.Parameters.ParametersParameterComponent;
+import org.hl7.fhir.r4.model.StringType;
 import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.Answers;
 import org.mockito.Mock;
 import org.mockito.Mockito;
 import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.boot.test.system.CapturedOutput;
+import org.springframework.boot.test.system.OutputCaptureExtension;
+
+import java.io.IOException;
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
 
 @ExtendWith(MockitoExtension.class)
+@ExtendWith(OutputCaptureExtension.class)
 public class FhirConnectorTest {
 
 
@@ -30,6 +43,7 @@ public class FhirConnectorTest {
 
   @Mock(answer = Answers.RETURNS_DEEP_STUBS)
   IGenericClient client;
+  @Mock private IOperationUntypedWithInput<Parameters> operation;
 
 
   FhirConnector fhirConnector;
@@ -56,25 +70,147 @@ public class FhirConnectorTest {
     BaseServerResponseException e = BaseServerResponseException.newInstance(200, "test");
     Mockito.when(client.transaction().withBundle(bundle).execute()).thenThrow(e);
 
-    assertThrows(IOException.class, () -> fhirConnector.transmitBundle(bundle));
+    assertThatThrownBy(() -> fhirConnector.transmitBundle(bundle))
+            .isInstanceOf(IOException.class);
   }
 
   @Test
   void testEvaluateMeasureSuccess() throws Exception {
-    MeasureReport measureReport = new MeasureReport();
+    var measureReport = new MeasureReport();
     measureReport.addGroup().addPopulation().setCount(MEASURE_COUNT);
+    var paramerters = new Parameters()
+            .addParameter(new ParametersParameterComponent()
+                    .setResource(measureReport));
 
-    Mockito.when(client.operation()
+    when(client.operation()
         .onType(Measure.class)
         .named("evaluate-measure")
         .withSearchParameter(Parameters.class, "measure", new StringParam(MEASURE_URI))
         .andSearchParameter("periodStart", new DateParam("1900"))
         .andSearchParameter("periodEnd", new DateParam("2100"))
-        .useHttpGet()
-        .returnResourceType(MeasureReport.class)
-        .execute()).thenReturn(measureReport);
+            .useHttpGet())
+                    .thenReturn(operation);
+    when(operation.preferResponseTypes(List.of(MeasureReport.class, Bundle.class, OperationOutcome.class)))
+            .thenReturn(operation);
+    when(operation
+        .execute()).thenReturn(paramerters);
 
-    assertEquals(MEASURE_COUNT, fhirConnector.evaluateMeasure(MEASURE_URI).getGroup().get(0).getPopulationFirstRep().getCount());
+    assertThat(fhirConnector.evaluateMeasure(MEASURE_URI).getGroup().get(0).getPopulationFirstRep().getCount())
+            .isEqualTo(MEASURE_COUNT);
+
+  }
+
+  @Test
+  @DisplayName("Result of evaluating measure is a Bundle containing the MeasureReport and gets processed correctly")
+  void testEvaluateMeasureSucceedsWithMeasureReportInBundle() throws Exception {
+      var measureReport = new MeasureReport();
+      var bundle = new Bundle().setEntry(List.of(new Bundle.BundleEntryComponent().setResource(measureReport)));
+      measureReport.addGroup().addPopulation().setCount(MEASURE_COUNT);
+      var paramerters = new Parameters()
+              .addParameter(new ParametersParameterComponent()
+                      .setResource(bundle));
+
+      when(client.operation()
+              .onType(Measure.class)
+              .named("evaluate-measure")
+              .withSearchParameter(Parameters.class, "measure", new StringParam(MEASURE_URI))
+              .andSearchParameter("periodStart", new DateParam("1900"))
+              .andSearchParameter("periodEnd", new DateParam("2100"))
+              .useHttpGet())
+      .thenReturn(operation);
+      when(operation.preferResponseTypes(List.of(MeasureReport.class, Bundle.class, OperationOutcome.class)))
+      .thenReturn(operation);
+      when(operation
+              .execute()).thenReturn(paramerters);
+
+      assertThat(fhirConnector.evaluateMeasure(MEASURE_URI).getGroup().get(0).getPopulationFirstRep().getCount())
+              .isEqualTo(MEASURE_COUNT);
+
+  }
+
+  @Test
+  @DisplayName("OperationOutcome issue message of failed operation gets logged")
+  void testEvaluateMeasureFailsWithOperationOutcome(CapturedOutput output) throws Exception {
+      var issueMessage = "foobar-042104";
+      var outcome = new OperationOutcome()
+              .setIssue(List.of(new OperationOutcome.OperationOutcomeIssueComponent().setDiagnostics(issueMessage)));
+      var paramerters = new Parameters()
+              .addParameter(new ParametersParameterComponent()
+                      .setResource(outcome));
+
+      when(client.operation()
+              .onType(Measure.class)
+              .named("evaluate-measure")
+              .withSearchParameter(Parameters.class, "measure", new StringParam(MEASURE_URI))
+              .andSearchParameter("periodStart", new DateParam("1900"))
+              .andSearchParameter("periodEnd", new DateParam("2100"))
+              .useHttpGet())
+                      .thenReturn(operation);
+      when(operation.preferResponseTypes(List.of(MeasureReport.class, Bundle.class, OperationOutcome.class)))
+              .thenReturn(operation);
+      when(operation
+              .execute()).thenReturn(paramerters);
+
+      assertThatThrownBy(() -> fhirConnector.evaluateMeasure(MEASURE_URI))
+              .isInstanceOf(IOException.class);
+      assertThat(output.getOut()).contains(issueMessage);
+
+  }
+
+  @Test
+  @DisplayName("evaluating measure returns Bundle with unknown resource type entry")
+  void testEvaluateMeasureFailsWithBundleContainingInvalidResourceType(CapturedOutput output) throws Exception {
+      var resource = new CapabilityStatement()
+              .setSoftware(new CapabilityStatementSoftwareComponent(new StringType("name-073450")));
+      var bundle = new Bundle().addEntry(new Bundle.BundleEntryComponent().setResource(resource));
+      var paramerters = new Parameters()
+              .addParameter(new ParametersParameterComponent()
+                      .setResource(bundle));
+
+      when(client.operation()
+              .onType(Measure.class)
+              .named("evaluate-measure")
+              .withSearchParameter(Parameters.class, "measure", new StringParam(MEASURE_URI))
+              .andSearchParameter("periodStart", new DateParam("1900"))
+              .andSearchParameter("periodEnd", new DateParam("2100"))
+              .useHttpGet())
+      .thenReturn(operation);
+      when(operation.preferResponseTypes(List.of(MeasureReport.class, Bundle.class, OperationOutcome.class)))
+      .thenReturn(operation);
+      when(operation
+              .execute()).thenReturn(paramerters);
+
+      assertThatThrownBy(() -> fhirConnector.evaluateMeasure(MEASURE_URI))
+      .isInstanceOf(IOException.class);
+      assertThat(output.getOut()).contains("Failed to extract MeasureReport from Bundle");
+
+  }
+
+  @Test
+  @DisplayName("evaluating measure returns Bundle with unknown resource type entry")
+  void testEvaluateMeasureFailsWithInvalidResourceType(CapturedOutput output) throws Exception {
+      var resource = new CapabilityStatement()
+              .setSoftware(new CapabilityStatementSoftwareComponent(new StringType("name-073450")));
+      var paramerters = new Parameters()
+              .addParameter(new ParametersParameterComponent()
+                      .setResource(resource));
+
+      when(client.operation()
+              .onType(Measure.class)
+              .named("evaluate-measure")
+              .withSearchParameter(Parameters.class, "measure", new StringParam(MEASURE_URI))
+              .andSearchParameter("periodStart", new DateParam("1900"))
+              .andSearchParameter("periodEnd", new DateParam("2100"))
+              .useHttpGet())
+                      .thenReturn(operation);
+      when(operation.preferResponseTypes(List.of(MeasureReport.class, Bundle.class, OperationOutcome.class)))
+              .thenReturn(operation);
+      when(operation
+              .execute()).thenReturn(paramerters);
+
+      assertThatThrownBy(() -> fhirConnector.evaluateMeasure(MEASURE_URI))
+              .isInstanceOf(IOException.class);
+      assertThat(output.getOut()).contains("unexpected resource type");
 
   }
 
@@ -87,11 +223,15 @@ public class FhirConnectorTest {
         .withSearchParameter(Parameters.class, "measure", new StringParam(MEASURE_URI))
         .andSearchParameter("periodStart", new DateParam("1900"))
         .andSearchParameter("periodEnd", new DateParam("2100"))
-        .useHttpGet()
-        .returnResourceType(MeasureReport.class)
-        .execute()).thenThrow(e);
+            .useHttpGet())
+            .thenReturn(operation);
+    when(operation.preferResponseTypes(List.of(MeasureReport.class, Bundle.class, OperationOutcome.class)))
+            .thenReturn(operation);
+    when(operation
+            .execute()).thenThrow(e);
 
-    assertThrows(IOException.class, () -> fhirConnector.evaluateMeasure(MEASURE_URI));
+    assertThatThrownBy(() -> fhirConnector.evaluateMeasure(MEASURE_URI))
+            .isInstanceOf(IOException.class);
   }
 
 }


### PR DESCRIPTION
Added configuration property `broker.direct.cql.useAsyncRequestPattern` with default value true to support asynchronous request handling when the Direct Broker is using CQL queries. This enhancement improves performance by allowing non-blocking request processing, particularly useful for complex or long-running CQL queries.

The change is part of the broker client configuration and can be controlled via the environment variable
`BROKER_CLIENT_DIRECT_CQL_USE_ASYNC_REQUEST_PATTERN` when needed and defaults to `false` for staying compatible with deployments using HAPI based CQL-enabled FHIR servers which reject requests with unknown headers.